### PR TITLE
Make undefined symbols a hygiene problem

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 cgName=coffeegrinder
 cgTitle=CoffeeGrinder
-cgVersion=0.4.1
+cgVersion=0.4.2
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeegrinder/parser/Grammar.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/Grammar.java
@@ -345,6 +345,29 @@ public class Grammar {
         }
     }
 
+    protected List<NonterminalSymbol> undefinedSymbols() {
+        HashSet<NonterminalSymbol> definedNames = new HashSet<>();
+        HashSet<NonterminalSymbol> usedNames = new HashSet<>();
+
+        for (Rule rule : rules) {
+            definedNames.add(rule.getSymbol());
+            for (Symbol s : rule.getRhs()) {
+                if (s instanceof NonterminalSymbol) {
+                    usedNames.add((NonterminalSymbol) s);
+                }
+            }
+        }
+
+        ArrayList<NonterminalSymbol> unused = new ArrayList<>();
+        for (NonterminalSymbol nt : usedNames) {
+            if (!definedNames.contains(nt)) {
+                unused.add(nt);
+            }
+        }
+
+        return unused;
+    }
+
     /**
      * Get a hygiene report for the specified start symbol.
      * <p>See {@link #checkHygiene(NonterminalSymbol)}.</p>
@@ -364,12 +387,17 @@ public class Grammar {
      */
     public HygieneReport checkHygiene(NonterminalSymbol seed) {
         HygieneReport report = new HygieneReport(this);
+
         HashSet<NonterminalSymbol> reachable = new HashSet<>();
         walk(seed, reachable);
         for (Rule rule : rules) {
             if (!reachable.contains(rule.getSymbol())) {
                 report.addUnreachable(rule.getSymbol());
             }
+        }
+
+        for (NonterminalSymbol nt : undefinedSymbols()) {
+            report.addUndefined(nt);
         }
 
         // What about unproductive non-terminals?

--- a/src/main/java/org/nineml/coffeegrinder/parser/HygieneReport.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/HygieneReport.java
@@ -14,14 +14,16 @@ public class HygieneReport {
 
     private final Grammar grammar;
     private final HashSet<Rule> unproductiveRules;
-    private final HashSet<NonterminalSymbol> unproductiveNonterminals;
+    private final HashSet<NonterminalSymbol> unproductiveSymbols;
     private final HashSet<NonterminalSymbol> unreachableSymbols;
+    private final HashSet<NonterminalSymbol> undefinedSymbols;
 
     protected HygieneReport(Grammar grammar) {
         this.grammar = grammar;
         unproductiveRules = new HashSet<>();
-        unproductiveNonterminals = new HashSet<>();
+        unproductiveSymbols = new HashSet<>();
         unreachableSymbols = new HashSet<>();
+        undefinedSymbols = new HashSet<>();
     }
 
     /**
@@ -30,8 +32,9 @@ public class HygieneReport {
      */
     public boolean isClean() {
         return unproductiveRules.isEmpty()
-                && unproductiveNonterminals.isEmpty()
-                && unreachableSymbols.isEmpty();
+                && unproductiveSymbols.isEmpty()
+                && unreachableSymbols.isEmpty()
+                && undefinedSymbols.isEmpty();
     }
 
     /**
@@ -57,7 +60,7 @@ public class HygieneReport {
      * @return the unproductive symbols.
      */
     public Set<NonterminalSymbol> getUnproductiveSymbols() {
-        return unproductiveNonterminals;
+        return unproductiveSymbols;
     }
 
     /**
@@ -66,6 +69,14 @@ public class HygieneReport {
      */
     public Set<NonterminalSymbol> getUnreachableSymbols() {
         return unreachableSymbols;
+    }
+
+    /**
+     * Get the unreachable symbols.
+     * @return the unreachable symbols.
+     */
+    public Set<NonterminalSymbol> getUndefinedSymbols() {
+        return undefinedSymbols;
     }
 
     protected void addUnreachable(NonterminalSymbol symbol) {
@@ -79,12 +90,23 @@ public class HygieneReport {
         }
     }
 
-    protected void addUnproductive(NonterminalSymbol symbol) {
-        if (unproductiveNonterminals.contains(symbol)) {
+    protected void addUndefined(NonterminalSymbol symbol) {
+        if (undefinedSymbols.contains(symbol)) {
             return;
         }
 
-        unproductiveNonterminals.add(symbol);
+        undefinedSymbols.add(symbol);
+        if (!grammar.isOpen()) {
+            grammar.getParserOptions().logger.warn(logcategory, "Undefined symbol: %s", symbol);
+        }
+    }
+
+    protected void addUnproductive(NonterminalSymbol symbol) {
+        if (unproductiveSymbols.contains(symbol)) {
+            return;
+        }
+
+        unproductiveSymbols.add(symbol);
         if (!grammar.isOpen()) {
             grammar.getParserOptions().logger.warn(logcategory, "Unproductive symbol: %s", symbol);
         }

--- a/src/main/java/org/nineml/coffeegrinder/parser/ParserOptions.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/ParserOptions.java
@@ -6,6 +6,7 @@ import org.nineml.logging.Logger;
 
 /**
  * Options to the parser.
+ * <p>This object is intentionally just a collection of public fields.</p>
  */
 public class ParserOptions {
     /**

--- a/src/main/java/org/nineml/coffeegrinder/parser/package-info.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/package-info.java
@@ -9,9 +9,9 @@
  *     <li>Create an {@link org.nineml.coffeegrinder.parser.EarleyParser EarleyParser} from the grammar.</li>
  *     <li>Parse a sequence of input tokens to obtain an {@link org.nineml.coffeegrinder.parser.EarleyResult}.</li>
  *     <li>From the result, you can get information about the success or failure of the parse, and possibly continue parsing.</li>
- *     <li>If the parse was successful, get the {@link org.nineml.coffeegrinder.parser.ParseForest SPPF} (shared packed parse forest) from the parse.</li>
- *     <li>Use the SPPF to get {@link org.nineml.coffeegrinder.parser.ParseTree SPPFTree} parse tree(s).</li>
- *     <li>The SPPF will also tell you about the ambiguity of the result, the number of parse trees available, etc.</li>
+ *     <li>If the parse was successful, get the {@link org.nineml.coffeegrinder.parser.ParseForest ParseForest} (a shared packed parse forest) from the parse.</li>
+ *     <li>Use the forest to get {@link org.nineml.coffeegrinder.parser.ParseTree ParseTree} parse tree(s).</li>
+ *     <li>The forest will also tell you about the ambiguity of the result, the number of parse trees available, etc.</li>
  * </ul>
  */
 package org.nineml.coffeegrinder.parser;

--- a/src/main/java/org/nineml/logging/SystemLogger.java
+++ b/src/main/java/org/nineml/logging/SystemLogger.java
@@ -3,12 +3,12 @@ package org.nineml.logging;
 import org.slf4j.LoggerFactory;
 
 /**
- * The system logger interfaces to a logging backend via a logging backend.
+ * The system logger routes messages to another logging framework.
  *
  * <p>This class supports either configuration with {@link org.slf4j.Logger org.slf4j.Logger} or
  * configuration directly with a {@link java.util.logging.Logger java.util.logging.Logger}.</p>
  *
- * <p>This logger makes it easy to configure the resolver to log through a standard
+ * <p>This logger makes it easy to configure logging through a standard
  * logging framework, as might be present on a Java application server. By default
  * the logger uses the {@link org.slf4j.LoggerFactory org.slf4j.LoggerFactory} to create a logger. This logger
  * can be supported at runtime by a wide variety of concrete backend classes. For details

--- a/src/main/java/org/nineml/logging/package-info.java
+++ b/src/main/java/org/nineml/logging/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Logging framework.
+ * <p>This package provides a simple logging framework that can either write
+ * directly to stderr or be linked to a more conventional logging framework.</p>
+ */
+package org.nineml.logging;

--- a/src/test/java/org/nineml/coffeegrinder/ParserTest.java
+++ b/src/test/java/org/nineml/coffeegrinder/ParserTest.java
@@ -2,6 +2,7 @@ package org.nineml.coffeegrinder;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.nineml.coffeegrinder.parser.*;
 import org.nineml.coffeegrinder.tokens.CharacterSet;
 import org.nineml.coffeegrinder.tokens.Token;
@@ -329,4 +330,54 @@ public class ParserTest {
         EarleyResult result = parser.parse(Iterators.characterIterator(input));
         Assert.assertTrue(result.succeeded());
     }
+
+    @Test
+    public void docExample() {
+        Grammar grammar = new Grammar();
+
+        NonterminalSymbol S = grammar.getNonterminal("S");
+        NonterminalSymbol A = grammar.getNonterminal("A");
+        NonterminalSymbol B = grammar.getNonterminal("B");
+        NonterminalSymbol X = grammar.getNonterminal("X");
+        NonterminalSymbol Y = grammar.getNonterminal("Y");
+
+        Rule s1 = new Rule(S, A);
+        grammar.addRule(s1);
+
+        grammar.addRule(S, B);
+        grammar.addRule(A, TerminalSymbol.ch('a'), X);
+        grammar.addRule(A, TerminalSymbol.ch('b'), X);
+        grammar.addRule(B, TerminalSymbol.ch('b'), X);
+        grammar.addRule(X, TerminalSymbol.ch('x'));
+        grammar.addRule(Y, TerminalSymbol.ch('y'));
+
+        grammar.close();
+
+        HygieneReport report = grammar.checkHygiene(S);
+        if (!report.isClean()) {
+            // TODO: deal with undefined, unused, and unproductive items
+        }
+
+        EarleyParser parser = grammar.getParser(S);
+
+        EarleyResult result = parser.parse("bx");
+
+        if (result.succeeded()) {
+            ParseForest forest = result.getForest();
+            ParseTree tree = forest.parse();
+
+            // TODO: do something with the tree.
+
+            if (forest.isAmbiguous()) {
+                long totalParses = forest.getTotalParses();
+                // TODO: deal with multiple parses
+            }
+        } else {
+            // TODO: deal with failure
+        }
+
+        Assertions.assertFalse(report.isClean());
+        Assertions.assertTrue(result.succeeded());
+    }
+
 }

--- a/src/website/xml/coffeegrinder.xml
+++ b/src/website/xml/coffeegrinder.xml
@@ -11,7 +11,7 @@
 <title>CoffeeGrinder</title>
 <subtitle>An Earley parser in Java</subtitle>
 <author>
-  <personname>Norm Tovey Walsh</personname>
+  <personname>Norm Tovey-Walsh</personname>
 </author>
 <copyright><year>2022</year><holder>Norm Tovey-Walsh</holder></copyright>
 <productname>coffeepot</productname>
@@ -21,19 +21,154 @@
 <preface>
 <title>Introduction</title>
 
-<para>This package provides an implementation of an Earley parser. The
-Earley parsing algorithm allows grammars to be ambiguous. This API
+<para>This package provides an implementation of an
+<link xlink:href="https://en.wikipedia.org/wiki/Earley_parser">Earley parser</link>. The
+Earley parsing algorithm is able to use grammars that are ambiguous. This API
 parses a sequence of tokens and returns a Shared Packed Parser Forest.
 Individual parse trees can be obtained from the forest.</para>
 
 </preface>
 
 <chapter>
-<title>JavaDoc</title>
+<title>General use</title>
 
-<para>Until other documention is available, the
-<link xlink:href="/apidoc">JavaDoc</link> will have to suffice.</para>
+<para>This is just an overview, consult the 
+<link xlink:href="/apidoc">JavaDoc</link> for more details.</para>
 
+<programlistingco>
+<areaspec>
+<area xml:id="ex_g" coords="1 55"/>
+<area xml:id="ex_ntg" coords="3 55"/>
+<area xml:id="ex_r1a" coords="9 35"/>
+<area xml:id="ex_r1b" coords="10 35"/>
+<area xml:id="ex_r2" coords="12 55"/>
+<area xml:id="ex_term" coords="13 55"/>
+<area xml:id="ex_close" coords="19 55"/>
+<area xml:id="ex_hyg" coords="21 55"/>
+<area xml:id="ex_parser" coords="27 55"/>
+<area xml:id="ex_result" coords="29 55"/>
+<area xml:id="ex_success" coords="31 55"/>
+<area xml:id="ex_forest" coords="32 55"/>
+<area xml:id="ex_tree" coords="33 55"/>
+<area xml:id="ex_amb" coords="37 55"/>
+</areaspec>
+<programlisting language="java">Grammar grammar = new Grammar();
+
+NonterminalSymbol S = grammar.getNonterminal("S");
+NonterminalSymbol A = grammar.getNonterminal("A");
+NonterminalSymbol B = grammar.getNonterminal("B");
+NonterminalSymbol X = grammar.getNonterminal("X");
+NonterminalSymbol Y = grammar.getNonterminal("Y");
+
+Rule s1 = new Rule(S, A);
+grammar.addRule(s1);
+
+grammar.addRule(S, B);
+grammar.addRule(A, TerminalSymbol.ch('a'), X);
+grammar.addRule(A, TerminalSymbol.ch('b'), X);
+grammar.addRule(B, TerminalSymbol.ch('b'), X);
+grammar.addRule(X, TerminalSymbol.ch('x'));
+grammar.addRule(Y, TerminalSymbol.ch('y'));
+
+grammar.close();
+
+HygieneReport report = grammar.checkHygiene(S);
+if (!report.isClean()) {
+    // TODO: deal with undefined,
+    // unused, and unproductive items
+}
+
+EarleyParser parser = grammar.getParser(S);
+
+EarleyResult result = parser.parse("bx");
+
+if (result.succeeded()) {
+    ParseForest forest = result.getForest();
+    ParseTree tree = forest.parse();
+
+    // TODO: do something with the tree.
+
+    if (forest.isAmbiguous()) {
+        long totalParses = forest.getTotalParses();
+        // TODO: deal with multiple parses
+    }
+} else {
+    // TODO: deal with failure
+}</programlisting>
+<calloutlist>
+<callout arearefs="ex_g">
+<para>Create a
+<link xlink:href="/apidoc/org/nineml/coffeegrinder/parser/Grammar.html">Grammar</link>.
+</para>
+</callout>
+<callout arearefs="ex_ntg">
+<para>Use the grammar to create nonterminal symbols.
+</para>
+</callout>
+<callout arearefs="ex_r1a">
+<para>Create rules mapping each nonterminal symbol to zero or more other symbols.
+</para>
+</callout>
+<callout arearefs="ex_r1b">
+<para>Add the rules to the grammar.
+</para>
+</callout>
+<callout arearefs="ex_r2">
+<para>You can also just use the <methodname>addRule</methodname> method to add
+the symbols and their mappings directly.
+</para>
+</callout>
+<callout arearefs="ex_term">
+<para>Several flavors of
+<link xlink:href="/apidoc/org/nineml/coffeegrinder/parser/TerminalSymbol.html">TerminalSymbol</link>
+are supported out-of-the-box and the set of
+<link xlink:href="/apidoc/org/nineml/coffeegrinder/tokens/Token.html">Tokens</link>
+is extensible.
+</para>
+</callout>
+<callout arearefs="ex_close">
+<para>Close the grammar when you’re finished adding to it. After a grammar
+is closed, it cannot be modified.
+</para>
+</callout>
+<callout arearefs="ex_hyg">
+<para><link xlink:href="/apidoc/org/nineml/coffeegrinder/parser/HygieneReport.html">Hygiene</link>
+problems with a closed grammar will generate warning messages through the
+<link xlink:href="/apidoc/org/nineml/logging/package-summary.html">logging framework</link>.
+Hygiene problems include undefined or unused symbols as well as unproductive symbols
+and rules.
+</para>
+</callout>
+<callout arearefs="ex_parser">
+<para>Create a
+<link xlink:href="/apidoc/org/nineml/coffeegrinder/parser/EarleyParser.html">parser</link>.
+</para>
+</callout>
+<callout arearefs="ex_result">
+<para>Parse some input.
+</para>
+</callout>
+<callout arearefs="ex_success">
+<para>Examine the
+<link xlink:href="/apidoc/org/nineml/coffeegrinder/parser/EarleyResult.html">results</link>.
+</para>
+</callout>
+<callout arearefs="ex_forest">
+<para>Obtain the
+<link xlink:href="/apidoc/org/nineml/coffeegrinder/parser/ParseForest.html">forest</link>.
+</para>
+</callout>
+<callout arearefs="ex_tree">
+<para>Get the (first)
+<link xlink:href="/apidoc/org/nineml/coffeegrinder/parser/ParseTree.html">parse tree</link>.
+</para>
+</callout>
+<callout arearefs="ex_amb">
+<para>If the parse was ambiguous, you can get additional parse trees.
+</para>
+</callout>
+</calloutlist>
+</programlistingco>
 </chapter>
 
 </book>


### PR DESCRIPTION
An undefined symbol no longer prevents the parse from being attempted. It will raise an exception if the parser attempts to use it. Undefined symbols are now reported as a hygiene issue.

A few documentation and javadoc improvements.