### PR TITLE
Remove the copy constructor from ParserOptions; other improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 cgName=coffeegrinder
 cgTitle=CoffeeGrinder
-cgVersion=0.5.1
+cgVersion=0.6.0
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeegrinder/parser/ParseTree.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/ParseTree.java
@@ -133,31 +133,6 @@ public class ParseTree {
                         id, xml, getSymbol() instanceof NonterminalSymbol ? "nonterminal" : "terminal");
             }
 
-            /*
-            boolean ambiguous = forest.isAmbiguous();
-            long totalParses = forest.treeManager.getTotalParses(node);  <- this isn't really a root
-            if (totalParses != 1) {
-                String parseCountStr, totalParseStr;
-                if (totalParses == Long.MAX_VALUE) {
-                    BigInteger total = forest.treeManager.getExactTotalParses();
-                    totalParseStr = total.toString();
-                    parseCountStr = total.subtract(forest.treeManager.getExactRemainingParses()).add(TreeManager.ONE).toString();
-                } else {
-                    long remainingParses = forest.treeManager.getRemainingParses(node);
-                    parseCountStr = "" + (totalParses - remainingParses + 1);
-                    totalParseStr = "" + totalParses;
-                }
-                stream.printf("%s parseNumber='%s' parseCount='%s'", ambiguous ? " ambiguous='true'" : "", parseCountStr, totalParseStr);
-            }
-             */
-            /*
-            if (parsenumber != null) {
-                stream.printf("%s parseNumber='%s' parseCount='%s'", ambiguous ? " ambiguous='true'" : "", parsenumber, totalparses);
-            } else {
-                stream.printf("%s", ambiguous ? " ambiguous='true'" : "");
-            }
-             */
-
             if (children.isEmpty()) {
                 if (nonterminal) {
                     stream.printf("><epsilon/></%s>\n", localName);

--- a/src/main/java/org/nineml/coffeegrinder/parser/ParserOptions.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/ParserOptions.java
@@ -54,15 +54,4 @@ public class ParserOptions {
         logger = new DefaultLogger();
         logger.readSystemProperties();
     }
-
-    /**
-     * A copy constructor.
-     * @param copy the options to copy.
-     */
-    public ParserOptions(ParserOptions copy) {
-        returnChart = copy.returnChart;
-        prefixParsing = copy.prefixParsing;
-        treesWithStates = copy.treesWithStates;
-        logger = copy.logger;
-    }
 }

--- a/src/main/java/org/nineml/coffeegrinder/util/DefaultProgressMonitor.java
+++ b/src/main/java/org/nineml/coffeegrinder/util/DefaultProgressMonitor.java
@@ -3,28 +3,55 @@ package org.nineml.coffeegrinder.util;
 import org.nineml.coffeegrinder.parser.EarleyParser;
 import org.nineml.coffeegrinder.parser.ProgressMonitor;
 
+/**
+ * A default implementation of {@link ProgressMonitor}.
+ */
 public class DefaultProgressMonitor implements ProgressMonitor {
+    /** The default update interval (number of tokens). */
     public static int frequency = 100;
+
     private final int size;
 
+    /**
+     * Create a monitor with the default update interval.
+     *
+     */
     public DefaultProgressMonitor() {
         this(frequency);
     }
 
+    /**
+     * Create a monitor with a specific update interval.
+     */
     public DefaultProgressMonitor(int size) {
         this.size = size;
     }
 
+    /**
+     * Start the monitor.
+     * @param parser the parser
+     * @return the update interval.
+     */
     @Override
     public int starting(EarleyParser parser) {
         return size;
     }
 
+    /**
+     * Report progress.
+     * <p>This implementation just prints a simple message to <code>System.out</code>.</p>
+     * @param parser the parser
+     * @param tokens the number of tokens processed so far.
+     */
     @Override
     public void progress(EarleyParser parser, long tokens) {
         System.out.printf("Processed %d tokens.%n", tokens);
     }
 
+    /**
+     * Finish the monitor.
+     * @param parser the parser
+     */
     @Override
     public void finished(EarleyParser parser) {
         // nop

--- a/src/main/java/org/nineml/coffeegrinder/util/GrammarCompiler.java
+++ b/src/main/java/org/nineml/coffeegrinder/util/GrammarCompiler.java
@@ -519,9 +519,7 @@ public class GrammarCompiler {
     }
 
     private Grammar parse(InputSource source) {
-        ParserOptions localOptions = new ParserOptions(options);
-        localOptions.treesWithStates = true;
-        grammar = new Grammar(localOptions);
+        grammar = new Grammar(options);
         properties = new ArrayList<>();
 
         initializeDigest();

--- a/src/main/java/org/nineml/coffeegrinder/util/StopWatch.java
+++ b/src/main/java/org/nineml/coffeegrinder/util/StopWatch.java
@@ -1,0 +1,104 @@
+package org.nineml.coffeegrinder.util;
+
+import java.util.Calendar;
+
+/**
+ * A utility class for managing a "wall clock" timer.
+ * <p>The timer starts when you create the object. Subsequent calls will return information
+ * based on the elapsed wall-clock time since the object was created. If <code>stop</code>
+ * is called, it will fix the end time.</p>
+ */
+public class StopWatch {
+    private static final int MS = 1000;
+    private static final int MINMS = MS * 60;
+    private static final int HOURMS = MINMS * 60;
+    private static final int DAYMS = HOURMS * 24;
+
+    private final long startTime;
+    private long endTime;
+
+    /**
+     * Create a stopwatch.
+     * <p>Time begins counting immediately.</p>
+     */
+    public StopWatch() {
+        startTime = Calendar.getInstance().getTimeInMillis();
+        endTime = 0;
+    }
+
+    /**
+     * Stop the watch.
+     * <p>After calling this method, the time will remain fixed.</p>
+     */
+    public void stop() {
+        endTime = Calendar.getInstance().getTimeInMillis();
+    }
+
+    /**
+     * The number of milliseconds that the stopwatch has been running.
+     * <p>Or, if <code>stop</code> has been called, how long it ran.</p>
+     * @return the number of milliseconds
+     */
+    public long duration() {
+        if (endTime != 0) {
+            return endTime - startTime;
+        }
+        return Calendar.getInstance().getTimeInMillis() - startTime;
+    }
+
+    /**
+     * Compute events per second.
+     * <p>Computes events per second for the given number of events. It returns
+     * a string of the form <code>%3.1f</code>.</p>
+     * @param events The number of events
+     * @return A formatted string
+     */
+    public String perSecond(long events) {
+        if (duration() == 0) {
+            return "∞";
+        }
+        return String.format("%3.1f", (1.0*events) / (duration() / 1000.0));
+    }
+
+    /**
+     * The elapsed time in a human-friendly format.
+     * <p>This method uses the timer's elapsed time.</p>
+     * @return A formatted string
+     */
+    public String elapsed() {
+        return elapsed(duration());
+    }
+
+    /**
+     * The elapsed time in a human-friendly format.
+     * <p>Returns the number of days, minutes, hours, and seconds represented by
+     * the duration, a number of milliseconds. For example,
+     * 103,010,000ms is "1d4h36m50s".</p>
+     * @param duration the duration in milliseconds
+     * @return A formatted string
+     */
+    public String elapsed(long duration) {
+        long days = Math.floorDiv(duration, DAYMS);
+
+        long left = duration - (days * DAYMS);
+        long hours = Math.floorDiv(left, HOURMS);
+        left = left - (hours * HOURMS);
+
+        long minutes = Math.floorDiv(left, MINMS);
+        left = left - (minutes * MINMS);
+
+        StringBuilder sb = new StringBuilder();
+        if (days > 0) {
+            sb.append(days).append("d");
+        }
+        if (days > 0 || hours > 0) {
+            sb.append(hours).append("h");
+        }
+        if (days > 0 || hours > 0 || minutes > 0) {
+            sb.append(minutes).append("m");
+        }
+        sb.append((int) left / 1000).append("s");
+
+        return sb.toString();
+    }
+}

--- a/src/test/java/org/nineml/coffeegrinder/IxmlTest.java
+++ b/src/test/java/org/nineml/coffeegrinder/IxmlTest.java
@@ -23,7 +23,6 @@ public class IxmlTest {
     public void testRuleParse() {
         try {
             ParserOptions options = new ParserOptions();
-            options.treesWithStates = true;
             Grammar grammar = new GrammarCompiler().parse(new File("src/test/resources/ixml.cxml"));
             grammar.setParserOptions(options);
 

--- a/src/test/java/org/nineml/coffeegrinder/StopWatchTest.java
+++ b/src/test/java/org/nineml/coffeegrinder/StopWatchTest.java
@@ -32,6 +32,7 @@ public class StopWatchTest {
         StopWatch stopWatch = new StopWatch();
         try {
             Thread.sleep(500);
+            stopWatch.stop();
         } catch (InterruptedException ex) {
             fail();
         }
@@ -39,8 +40,8 @@ public class StopWatchTest {
         // I don't trust Thread.sleep to be that accurate...
         double perS = Double.parseDouble(stopWatch.perSecond(1000));
 
-        Assertions.assertTrue(perS > 1.9);
-        Assertions.assertTrue(perS < 2.1);
+        Assertions.assertTrue(perS > 1999.0);
+        Assertions.assertTrue(perS < 2001.0);
     }
 
     @Test

--- a/src/test/java/org/nineml/coffeegrinder/StopWatchTest.java
+++ b/src/test/java/org/nineml/coffeegrinder/StopWatchTest.java
@@ -1,0 +1,56 @@
+package org.nineml.coffeegrinder;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.nineml.coffeegrinder.util.StopWatch;
+
+import static org.junit.Assert.fail;
+
+public class StopWatchTest {
+    @Test
+    public void testTimer() {
+        StopWatch stopWatch = new StopWatch();
+        long first = 0;
+        long second = 0;
+        try {
+            Thread.sleep(250);
+            first = stopWatch.duration();
+            Thread.sleep(250);
+            stopWatch.stop();
+            second = stopWatch.duration();
+            Thread.sleep(250);
+        } catch (InterruptedException ex) {
+            fail();
+        }
+        Assertions.assertTrue(first > 200);
+        Assertions.assertTrue(second > first);
+        Assertions.assertEquals(second, stopWatch.duration());
+    }
+
+    @Test
+    public void testPerSecond() {
+        StopWatch stopWatch = new StopWatch();
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException ex) {
+            fail();
+        }
+
+        // I don't trust Thread.sleep to be that accurate...
+        double perS = Double.parseDouble(stopWatch.perSecond(1000));
+
+        Assertions.assertTrue(perS > 1.9);
+        Assertions.assertTrue(perS < 2.1);
+    }
+
+    @Test
+    public void testFormatter() {
+        StopWatch stopWatch = new StopWatch();
+        Assertions.assertEquals("3s", stopWatch.elapsed(3000));
+        Assertions.assertEquals("30s", stopWatch.elapsed(30000));
+        Assertions.assertEquals("5m1s", stopWatch.elapsed(301000));
+        Assertions.assertEquals("50m10s", stopWatch.elapsed(3010000));
+        Assertions.assertEquals("1d4h36m50s", stopWatch.elapsed(103010000));
+        Assertions.assertEquals("24d8h10m10s", stopWatch.elapsed(2103010000));
+    }
+}


### PR DESCRIPTION
The copy constructor encourages code to make copies of the options object, which then hides the object from the caller. Not useful. So to prevent myself from "helpfully" doing that again, I removed it.

I added a `StopWatch` component to track wall clock time. It's used by the EarleyParser, but will also be used in CoffeePot for the progress monitor.

Added some JavaDoc; bumped the version because of the API change.