### PR TITLE
Fixes to compiled grammar and logging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 cgName=coffeegrinder
 cgTitle=CoffeeGrinder
-cgVersion=0.8.0
+cgVersion=0.8.1
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/logging/Logger.java
+++ b/src/main/java/org/nineml/logging/Logger.java
@@ -1,6 +1,7 @@
 package org.nineml.logging;
 
 import java.util.HashMap;
+import java.util.Set;
 
 /**
  * The abstract class that all concrete loggers must extend.
@@ -58,7 +59,7 @@ public abstract class Logger {
 
     private int defaultLogLevel = ERROR;
 
-    private static final HashMap<String,Integer> logLevels = new HashMap<>();
+    private final HashMap<String,Integer> logLevels = new HashMap<>();
 
     /**
      * Set the log levels by reading system properties.
@@ -139,6 +140,14 @@ public abstract class Logger {
     }
 
     /**
+     * Get all of the configured log level categories
+     * @return the set of categories
+     */
+    public Set<String> getLogCategories() {
+        return logLevels.keySet();
+    }
+
+    /**
      * Get the log level for a particular category.
      * <p>Category names are not case sensitive.</p>
      * @param category the category
@@ -205,6 +214,15 @@ public abstract class Logger {
                 error(logcategory, "Cannot parse log level setting: %s", pair);
             }
         }
+    }
+
+    /**
+     * Clear the log levels.
+     * <p>This method removes all configured log levels. All subsequent logging (until more
+     * levels are set) will be based entirely on the default log level.</p>
+     */
+    public void clearLogLevels() {
+        logLevels.clear();
     }
 
     protected String message(String category, int level, String message, Object... params) {

--- a/src/test/java/org/nineml/coffeegrinder/LoggerTest.java
+++ b/src/test/java/org/nineml/coffeegrinder/LoggerTest.java
@@ -2,8 +2,11 @@ package org.nineml.coffeegrinder;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.nineml.logging.DefaultLogger;
 import org.nineml.logging.Logger;
+
+import java.util.Set;
 
 import static junit.framework.TestCase.fail;
 
@@ -125,6 +128,36 @@ public class LoggerTest {
         }
     }
 
+    @Test
+    public void testCategories() {
+        Logger logger = new DefaultLogger();
+        logger.setLogLevels("a:1,b:2,c:info,d:warning");
 
+        Assert.assertEquals(Logger.ERROR, logger.getLogLevel("a"));
+        Assert.assertEquals(Logger.WARNING, logger.getLogLevel("b"));
+        Assert.assertEquals(Logger.INFO, logger.getLogLevel("c"));
+        Assert.assertEquals(Logger.WARNING, logger.getLogLevel("d"));
 
+        Set<String> cats = logger.getLogCategories();
+        Assertions.assertTrue(cats.contains("a"));
+        Assertions.assertTrue(cats.contains("b"));
+        Assertions.assertTrue(cats.contains("c"));
+        Assertions.assertTrue(cats.contains("d"));
+        Assertions.assertEquals(4, cats.size());
+    }
+
+    @Test
+    public void testClear() {
+        Logger logger = new DefaultLogger();
+        logger.setLogLevels("a:1,b:2,c:info,d:warning");
+
+        Assert.assertEquals(Logger.ERROR, logger.getLogLevel("a"));
+
+        Set<String> cats = logger.getLogCategories();
+        Assertions.assertTrue(cats.contains("a"));
+        Assertions.assertEquals(4, cats.size());
+
+        logger.clearLogLevels();
+        Assertions.assertEquals(0, logger.getLogCategories().size());
+    }
 }


### PR DESCRIPTION
The grammar compiler blindly encoded non-XML characters with numeric character references. It now uses a different encoding for those characters.

Added the `getLogCategories` and `clearLogLevels` methods to the logger. Close #36 