### PR TITLE
Support metadata on Grammar; use that in GrammarCompiler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 cgName=coffeegrinder
 cgTitle=CoffeeGrinder
-cgVersion=0.8.2
+cgVersion=0.9.0
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeegrinder/parser/Grammar.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/Grammar.java
@@ -22,6 +22,7 @@ public class Grammar {
     private final HashSet<NonterminalSymbol> nonterminals;
     private final HashSet<NonterminalSymbol> nullable;
     protected final int id;
+    private final HashMap<String,String> metadata = new HashMap<>();
     private ParserOptions options;
     private boolean open = true;
 
@@ -297,6 +298,56 @@ public class Grammar {
             }
         }
         return false;
+    }
+
+    /**
+     * Sets a metadata property.
+     * <p>Metadata properties exist solely for annotations by an application. They have
+     * no bearing on the function of the grammar. The {@link org.nineml.coffeegrinder.util.GrammarCompiler GrammarCompiler}
+     * stores metadata properties in the compiled grammar and they are restored when a parsed
+     * grammar is loaded.</p>
+     * @param name the name of the property
+     * @param value the value of the property, or null to remove a property
+     * @throws NullPointerException if the name is null
+     */
+    public void setMetadataProperty(String name, String value) {
+        if (name == null) {
+            throw new NullPointerException("Name must not be null");
+        }
+        if (value == null) {
+            metadata.remove(name);
+        } else {
+            metadata.put(name, value);
+        }
+    }
+
+    /**
+     * Gets a metadata property.
+     * <p>Metadata properties exist solely for annotations by an application. They have
+     * no bearing on the function of the grammar. The {@link org.nineml.coffeegrinder.util.GrammarCompiler GrammarCompiler}
+     * stores metadata properties in the compiled grammar and they are restored when a parsed
+     * grammar is loaded.</p>
+     * @param name the name of the property
+     * @return the value of the property, or null if no such property exists
+     * @throws NullPointerException if the name is null
+     */
+    public String getMetadataProperty(String name) {
+        if (name == null) {
+            throw new NullPointerException("Name must not be null");
+        }
+        return metadata.getOrDefault(name, null);
+    }
+
+    /**
+     * Gets the metadata properties.
+     * <p>Metadata properties exist solely for annotations by an application. They have
+     * no bearing on the function of the grammar. The {@link org.nineml.coffeegrinder.util.GrammarCompiler GrammarCompiler}
+     * stores metadata properties in the compiled grammar and they are restored when a parsed
+     * grammar is loaded.</p>
+     * @return the metadata properties
+     */
+    public Map<String,String> getMetadataProperies() {
+        return metadata;
     }
 
     protected void computeNullable(Rule rule) {

--- a/src/test/java/org/nineml/coffeegrinder/CompilerTest.java
+++ b/src/test/java/org/nineml/coffeegrinder/CompilerTest.java
@@ -98,27 +98,15 @@ public class CompilerTest {
         GrammarCompiler compiler = new GrammarCompiler();
         Grammar grammar = compiler.parse(cxml);
 
-        /*
-        System.err.println("=====");
-        System.err.println(compiler.compile(grammar));
-        System.err.println("=====");
-         */
-
         NonterminalSymbol start = grammar.getNonterminal("hashes");
         EarleyParser parser = grammar.getParser(start);
         EarleyResult result = parser.parse("#12.");
 
         Assert.assertTrue(result.succeeded());
 
-        compiler.setProperty("Source", "Invisible XML test suite");
-        compiler.setProperty("Date", "2022-01-30");
+        grammar.setMetadataProperty("Source", "Invisible XML test suite");
+        grammar.setMetadataProperty("Date", "2022-01-30");
         String compiled = compiler.compile(grammar);
-
-        /*
-        System.err.println("=====");
-        System.err.println(compiled);
-        System.err.println("=====");
-        */
 
         Assert.assertEquals(cxml, compiled);
     }

--- a/src/test/resources/hash.cxml
+++ b/src/test/resources/hash.cxml
@@ -1,6 +1,6 @@
 <grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="0.9.2">
-<meta name='Source' value='Invisible XML test suite'/>
 <meta name='Date' value='2022-01-30'/>
+<meta name='Source' value='Invisible XML test suite'/>
 <ag xml:id="g1" name="$$" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
 <ag xml:id="g2" name="hashes" mark="^"/>
 <r n="$$" a="p" ag="g1"><nt n="hashes" ag="g2"/></r>


### PR DESCRIPTION
This removes the get/set property methods on the `GrammarCompiler` in favor of storing the metadata in the `Grammar`.