### PR TITLE
Fix grammar construction error; add moreInput() method

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 cgName=coffeegrinder
 cgTitle=CoffeeGrinder
-cgVersion=0.9.0
+cgVersion=0.9.1
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeegrinder/parser/EarleyParser.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/EarleyParser.java
@@ -339,6 +339,12 @@ public class EarleyParser {
 
         timer.stop();
 
+        // If we weren't buffering, but we didn't reach the end of the input,
+        // make sure the next token is available.
+        if (!buffering && !lastToken) {
+            tokenBuffer.add(nextToken);
+        }
+
         if (monitor != null) {
             if (progressSize > 0) {
                 monitor.progress(this, tokenCount);
@@ -416,6 +422,17 @@ public class EarleyParser {
         result.setParseTime(timer.duration());
 
         return result;
+    }
+
+    /**
+     * Is there more input?
+     * <p>If the parse succeeded, the answer will always be false. But a failed parse
+     * can fail because it was unable to process a token or because it ran out of tokens.
+     * This method checks if there was any more input after the parse completed.</p>
+     * @return true if parsing failed before the entire input was consumed
+     */
+    public boolean moreInput() {
+        return !tokenBuffer.isEmpty() || iterator.hasNext();
     }
 
     private ForestNode make_node(State B, int j, int i, ForestNode w, ForestNode v) {

--- a/src/main/java/org/nineml/coffeegrinder/parser/Grammar.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/Grammar.java
@@ -267,7 +267,7 @@ public class Grammar {
      * Does this grammar contain an equivalent rule?
      * <p>Two rules are equivalent if they have the same symbol, the same list of right-hand-side
      * symbols, and if the optionality of every symbol on the right-hand-side is the same in both rules.</p>
-     * @param candidate the candidat rule
+     * @param candidate the candidate rule
      * @return true if the grammar contains an equivalent rule
      */
     public boolean contains(Rule candidate) {
@@ -389,7 +389,12 @@ public class Grammar {
                     }
                 }
                 Rule newRule = new Rule(rule.getSymbol(), newRhs);
-                addRule(newRule);
+                // The contains() test is in some sense unnecessary here because addRule() tests
+                // for this. But addRule() generates a trace message if the rules are the same
+                // and that's potentially misleading here, so let's avoid it.
+                if (!contains(newRule)) {
+                    addRule(newRule);
+                }
                 expandOptionalSymbols(newRule, pos);
             }
         }

--- a/src/main/java/org/nineml/coffeegrinder/tokens/TokenCharacterSet.java
+++ b/src/main/java/org/nineml/coffeegrinder/tokens/TokenCharacterSet.java
@@ -168,6 +168,44 @@ public class TokenCharacterSet extends Token {
         return false;
     }
 
+    /**
+     * Are two token character sets "equal"?
+     * <p>This method checks to see if they contain the same ranges. That's not the only
+     * possible definition of equality. For example, a set with the single range ['0'-'9']
+     * is in some sense "the same" as a set with the ranges ['0'-'5'] and ['6'-'9'], but
+     * they would not be equal by this method.</p>
+     * <p>It's temping to write an equality function in broader terms, but to do it correctly,
+     * it would be necessary to be able to compare Unicode classes to other kinds of ranges
+     * and that seems impractical.</p>
+     * @param obj the object to test
+     * @return true if they are equal
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof TokenCharacterSet) {
+            TokenCharacterSet other = (TokenCharacterSet) obj;
+            if (inclusion == other.inclusion && ranges.size() == other.ranges.size()) {
+                // If every character set is .equal() to a range in the other,
+                // then they're the same. This means the ranges don't have to
+                // appear in the same order.
+                for (CharacterSet range : ranges) {
+                    boolean same = false;
+                    for (CharacterSet otherRange: other.ranges) {
+                        if (range.equals(otherRange)) {
+                            same = true;
+                            break;
+                        }
+                    }
+                    if (!same) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
This PR fixes an API error. The `TokenCharacterSet` failed to implement `.equals()`, consequently all character sets compared "not equal". That could lead to duplicated rules in the grammar which in turn could lead to apparent ambiguities that did not really exist. (Two identical rules gives the parser two solutions and creates ambiguity.)

Also added an API to report whether or not more input was available. This allows https://github.com/nineml/coffeefilter/issues/39 to be fixed.