### PR TITLE
Bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 cgName=coffeegrinder
 cgTitle=CoffeeGrinder
-cgVersion=0.9.1
+cgVersion=0.9.2
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeegrinder/exceptions/MessageGenerator.java
+++ b/src/main/java/org/nineml/coffeegrinder/exceptions/MessageGenerator.java
@@ -74,6 +74,7 @@ public class MessageGenerator {
                 int pnum = 1;
                 for (String param : params) {
                     String subst = "%" + pnum;
+                    param = param.replaceAll("\\$", "\\\\\\$");
                     message = message.replaceAll(subst, param);
                     pnum++;
                 }

--- a/src/main/java/org/nineml/coffeegrinder/parser/ParseTree.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/ParseTree.java
@@ -70,8 +70,8 @@ public class ParseTree {
      *
      * @return The parent node in the tree, or null if this is the root
      */
-    public ForestNode getParent() {
-        return node;
+    public ParseTree getParent() {
+        return parent;
     }
 
     /**


### PR DESCRIPTION
A couple of simple bugs:
1. The definition of `getParent()` was just wrong (it returned the node, not the parent)
2. The message generate didn't escape `$` so `replaceAll()` would attempt to expand groups.
