### PR TITLE
Fix bug on Windows, rename CompiledGrammar class

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 cgName=coffeegrinder
 cgTitle=CoffeeGrinder
-cgVersion=1.99.7
+cgVersion=1.99.8
 
-xmlresolverVersion=4.3.0
+xmlresolverVersion=4.4.0
 docbookVersion=5.2b12
 xslTNGversion=1.7.0-11
 

--- a/src/main/java/org/nineml/coffeegrinder/gll/BinarySubtree.java
+++ b/src/main/java/org/nineml/coffeegrinder/gll/BinarySubtree.java
@@ -2,9 +2,7 @@ package org.nineml.coffeegrinder.gll;
 
 import org.nineml.coffeegrinder.parser.*;
 import org.nineml.coffeegrinder.tokens.Token;
-import org.nineml.coffeegrinder.util.ParserAttribute;
 import org.nineml.coffeegrinder.util.StopWatch;
-import org.nineml.logging.Logger;
 
 import java.util.*;
 
@@ -108,7 +106,7 @@ public class BinarySubtree {
         return roots;
     }
 
-    protected ParseForest extractSPPF(CompiledGrammar grammar, Token[] inputTokens) {
+    protected ParseForest extractSPPF(ParserGrammar grammar, Token[] inputTokens) {
         ParseForestGLL G = new ParseForestGLL(grammar.getParserOptions(), grammar, rightExtent, inputTokens, regexMatches);
         int n = rightExtent;
 

--- a/src/main/java/org/nineml/coffeegrinder/gll/GllParser.java
+++ b/src/main/java/org/nineml/coffeegrinder/gll/GllParser.java
@@ -14,7 +14,7 @@ import java.util.*;
 public class GllParser implements GearleyParser {
     public static final String logcategory = "Parser";
     public static final String gllexecution = "GLLExecution";
-    public final CompiledGrammar grammar;
+    public final ParserGrammar grammar;
     private final ArrayList<State> grammarSlots;
     private final HashMap<Rule,List<State>> ruleSlots;
     private Token[] I;
@@ -44,7 +44,7 @@ public class GllParser implements GearleyParser {
     protected int tokenCount;
     protected Token lastToken;
 
-    public GllParser(CompiledGrammar grammar, ParserOptions options) {
+    public GllParser(ParserGrammar grammar, ParserOptions options) {
         this.grammar = grammar;
         this.options = options;
         logger = options.getLogger();
@@ -75,7 +75,7 @@ public class GllParser implements GearleyParser {
         return ParserType.GLL;
     }
 
-    public CompiledGrammar getGrammar() {
+    public ParserGrammar getGrammar() {
         return grammar;
     }
 

--- a/src/main/java/org/nineml/coffeegrinder/parser/EarleyParser.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/EarleyParser.java
@@ -3,9 +3,7 @@ package org.nineml.coffeegrinder.parser;
 import org.nineml.coffeegrinder.exceptions.ParseException;
 import org.nineml.coffeegrinder.tokens.Token;
 import org.nineml.coffeegrinder.tokens.TokenCharacter;
-import org.nineml.coffeegrinder.tokens.TokenEOF;
 import org.nineml.coffeegrinder.tokens.TokenString;
-import org.nineml.coffeegrinder.util.Iterators;
 import org.nineml.coffeegrinder.util.ParserAttribute;
 import org.nineml.coffeegrinder.util.StopWatch;
 
@@ -25,7 +23,7 @@ public class EarleyParser implements GearleyParser {
 
     private final EarleyChart chart = new EarleyChart();
     private final ForestNodeSet V;
-    private final CompiledGrammar grammar;
+    private final ParserGrammar grammar;
     private final ParseForest graph;
     private final NonterminalSymbol S;
     private final HashMap<NonterminalSymbol, List<Rule>> Rho;
@@ -43,7 +41,7 @@ public class EarleyParser implements GearleyParser {
     protected int progressSize = 0;
     protected int progressCount = 0;
 
-    protected EarleyParser(CompiledGrammar grammar, ParserOptions options) {
+    protected EarleyParser(ParserGrammar grammar, ParserOptions options) {
         this.grammar = grammar;
         this.options = options;
 
@@ -126,7 +124,7 @@ public class EarleyParser implements GearleyParser {
      * Get the grammar used by this parser.
      * @return the grammar
      */
-    public CompiledGrammar getGrammar() {
+    public ParserGrammar getGrammar() {
         return grammar;
     }
 

--- a/src/main/java/org/nineml/coffeegrinder/parser/GearleyParser.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/GearleyParser.java
@@ -6,7 +6,7 @@ import java.util.Iterator;
 
 public interface GearleyParser {
     ParserType getParserType();
-    CompiledGrammar getGrammar();
+    ParserGrammar getGrammar();
     NonterminalSymbol getSeed();
     GearleyResult parse(Token[] input);
     GearleyResult parse(Iterator<Token> input);

--- a/src/main/java/org/nineml/coffeegrinder/parser/Grammar.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/Grammar.java
@@ -11,7 +11,7 @@ public abstract class Grammar {
 
     /**
      * Get the rules currently defined in this grammar.
-     * <p>For a {@link CompiledGrammar}, this is the final set.</p>
+     * <p>For a {@link ParserGrammar}, this is the final set.</p>
      * @return Returns the rules that define the grammar.
      */
     public List<Rule> getRules() {
@@ -20,7 +20,7 @@ public abstract class Grammar {
 
     /**
      * Get the currently defined nonterminals in the grammar.
-     * <p>For a {@link CompiledGrammar}, this is the final set.</p>
+     * <p>For a {@link ParserGrammar}, this is the final set.</p>
      * @return the set of nonterminals.
      */
     public Set<NonterminalSymbol> getSymbols() {
@@ -29,7 +29,7 @@ public abstract class Grammar {
 
     /**
      * Get the rules currently defined in this grammar organized by symbol.
-     * <p>For a {@link CompiledGrammar}, this is the final set.</p>
+     * <p>For a {@link ParserGrammar}, this is the final set.</p>
      * @return Returns the rules that define the grammar.
      */
     public Map<NonterminalSymbol,List<Rule>> getRulesBySymbol() {
@@ -38,7 +38,7 @@ public abstract class Grammar {
 
     /**
      * Get the rules currently defined in this grammar for a particular symbol.
-     * <p>For a {@link CompiledGrammar}, this is the final set.</p>
+     * <p>For a {@link ParserGrammar}, this is the final set.</p>
      * @param symbol The symbol.
      * @return Returns the rules that define the grammar.
      */
@@ -78,7 +78,7 @@ public abstract class Grammar {
     /**
      * Is the symbol nullable?
      * <p>A {@link TerminalSymbol} is never nullable.</p>
-     * <p>For a {@link CompiledGrammar}, the answer is definitive. For an {@link SourceGrammar},
+     * <p>For a {@link ParserGrammar}, the answer is definitive. For an {@link SourceGrammar},
      * a symbol that isn't currently nullable could become nullable by the addition of more rules.</p>
      * @param symbol The symbol.
      * @return true if the symbol is nullable

--- a/src/main/java/org/nineml/coffeegrinder/parser/HygieneReport.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/HygieneReport.java
@@ -12,27 +12,27 @@ public class HygieneReport {
     public static final String logcategory = "Hygiene";
 
     private final SourceGrammar grammar;
-    private final CompiledGrammar compiledGrammar;
+    private final ParserGrammar parserGrammar;
     private final HashSet<Rule> unproductiveRules = new HashSet<>();
     private final HashSet<NonterminalSymbol> unproductiveSymbols = new HashSet<>();
     private final HashSet<NonterminalSymbol> unreachableSymbols = new HashSet<>();
     private final HashSet<NonterminalSymbol> undefinedSymbols = new HashSet<>();
     private ArrayList<Rule> rules = null;
 
-    protected HygieneReport(CompiledGrammar grammar) {
-        this.compiledGrammar = grammar;
+    protected HygieneReport(ParserGrammar grammar) {
+        this.parserGrammar = grammar;
         this.grammar = null;
         checkGrammar(grammar.getSeed());
     }
 
     protected HygieneReport(SourceGrammar grammar, NonterminalSymbol seed) {
-        this.compiledGrammar = null;
+        this.parserGrammar = null;
         this.grammar = grammar;
         checkGrammar(seed);
     }
 
     private void checkGrammar(NonterminalSymbol seed) {
-        if (compiledGrammar != null && rules != null) {
+        if (parserGrammar != null && rules != null) {
             return; // no reason to do this twice, it can't change...
         }
 
@@ -42,9 +42,9 @@ public class HygieneReport {
             rules.addAll(grammar.getRules());
             rulesBySymbol = grammar.getRulesBySymbol();
         } else {
-            assert compiledGrammar != null;
-            rules.addAll(compiledGrammar.getRules());
-            rulesBySymbol = compiledGrammar.getRulesBySymbol();
+            assert parserGrammar != null;
+            rules.addAll(parserGrammar.getRules());
+            rulesBySymbol = parserGrammar.getRulesBySymbol();
         }
 
 
@@ -163,8 +163,8 @@ public class HygieneReport {
      * may have changed since this report was created.</p>
      * @return the grammar.
      */
-    public CompiledGrammar getCompiledGrammar() {
-        return compiledGrammar;
+    public ParserGrammar getCompiledGrammar() {
+        return parserGrammar;
     }
 
     /**
@@ -205,8 +205,8 @@ public class HygieneReport {
         }
 
         unreachableSymbols.add(symbol);
-        if (compiledGrammar != null) {
-            compiledGrammar.getParserOptions().getLogger().warn(logcategory, "Unreachable symbol: %s", symbol);
+        if (parserGrammar != null) {
+            parserGrammar.getParserOptions().getLogger().warn(logcategory, "Unreachable symbol: %s", symbol);
         }
     }
 
@@ -216,8 +216,8 @@ public class HygieneReport {
         }
 
         undefinedSymbols.add(symbol);
-        if (compiledGrammar != null) {
-            compiledGrammar.getParserOptions().getLogger().warn(logcategory, "Undefined symbol: %s", symbol);
+        if (parserGrammar != null) {
+            parserGrammar.getParserOptions().getLogger().warn(logcategory, "Undefined symbol: %s", symbol);
         }
     }
 
@@ -227,8 +227,8 @@ public class HygieneReport {
         }
 
         unproductiveSymbols.add(symbol);
-        if (compiledGrammar != null) {
-            compiledGrammar.getParserOptions().getLogger().warn(logcategory, "Unproductive symbol: %s", symbol);
+        if (parserGrammar != null) {
+            parserGrammar.getParserOptions().getLogger().warn(logcategory, "Unproductive symbol: %s", symbol);
         }
     }
 
@@ -238,8 +238,8 @@ public class HygieneReport {
         }
 
         unproductiveRules.add(rule);
-        if (compiledGrammar != null) {
-            compiledGrammar.getParserOptions().getLogger().warn(logcategory, "Unproductive rule: %s", rule);
+        if (parserGrammar != null) {
+            parserGrammar.getParserOptions().getLogger().warn(logcategory, "Unproductive rule: %s", rule);
         }
     }
 }

--- a/src/main/java/org/nineml/coffeegrinder/parser/NonterminalSymbol.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/NonterminalSymbol.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 /**
  * A nonterminal symbol in the grammar.
  * <p>Every nonterminal must be defined by a {@link Rule Rule} in the
- * {@link CompiledGrammar Grammar}.</p>
+ * {@link ParserGrammar Grammar}.</p>
  */
 public class NonterminalSymbol extends Symbol {
     private final String name;

--- a/src/main/java/org/nineml/coffeegrinder/parser/ParseForestGLL.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/ParseForestGLL.java
@@ -17,12 +17,12 @@ public class ParseForestGLL extends ParseForest {
     private final HashMap<Symbol, PrefixTrie> slotPrefixes;
     private final HashMap<Symbol, HashMap<Integer, HashMap<Integer, ArrayList<ForestNodeGLL>>>> nodes;
     private final HashMap<PrefixTrie, HashMap<Integer, HashMap<Integer, ArrayList<ForestNodeGLL>>>> slots;
-    private final CompiledGrammar grammar;
+    private final ParserGrammar grammar;
     private final int rightExtent;
     private final Token[] inputTokens;
     private final Map<Integer,String> regexMatches;
 
-    public ParseForestGLL(ParserOptions options, CompiledGrammar grammar, int rightExtent, Token[] inputTokens, Map<Integer,String> regexMatches) {
+    public ParseForestGLL(ParserOptions options, ParserGrammar grammar, int rightExtent, Token[] inputTokens, Map<Integer,String> regexMatches) {
         super(options);
         this.grammar = grammar;
         this.rightExtent = rightExtent;

--- a/src/main/java/org/nineml/coffeegrinder/parser/ParserGrammar.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/ParserGrammar.java
@@ -1,8 +1,6 @@
 package org.nineml.coffeegrinder.parser;
 
 import org.nineml.coffeegrinder.gll.GllParser;
-import org.nineml.coffeegrinder.tokens.TokenRegex;
-import org.nineml.coffeegrinder.util.ParserAttribute;
 import org.nineml.coffeegrinder.util.RegexCompiler;
 
 import java.util.*;
@@ -16,7 +14,7 @@ import java.util.*;
  * <p>A grammar can be used to create a parser for that grammar. After doing so, you cannot make any
  * further changes to the grammar.</p>
  */
-public class CompiledGrammar extends Grammar {
+public class ParserGrammar extends Grammar {
     private final ParserType parserType;
     private final NonterminalSymbol seed;
     private final HashSet<Symbol> nullable;
@@ -25,7 +23,7 @@ public class CompiledGrammar extends Grammar {
     private final HashMap<NonterminalSymbol, HashSet<Symbol>> followSets = new HashMap<>();
     private boolean computedSets = false;
 
-    protected CompiledGrammar(SourceGrammar grammar, ParserType parserType, NonterminalSymbol seed) {
+    protected ParserGrammar(SourceGrammar grammar, ParserType parserType, NonterminalSymbol seed) {
         this.parserType = parserType;
         this.seed = seed;
 

--- a/src/main/java/org/nineml/coffeegrinder/parser/SourceGrammar.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/SourceGrammar.java
@@ -163,12 +163,12 @@ public class SourceGrammar extends Grammar {
         return getParser(options, getNonterminal(seed));
     }
 
-    public CompiledGrammar getCompiledGrammar(NonterminalSymbol seed) {
-        return new CompiledGrammar(this, defaultParserType, seed);
+    public ParserGrammar getCompiledGrammar(NonterminalSymbol seed) {
+        return new ParserGrammar(this, defaultParserType, seed);
     }
 
-    public CompiledGrammar getCompiledGrammar(ParserType parserType, NonterminalSymbol seed) {
-        return new CompiledGrammar(this, parserType, seed);
+    public ParserGrammar getCompiledGrammar(ParserType parserType, NonterminalSymbol seed) {
+        return new ParserGrammar(this, parserType, seed);
     }
 
     /**
@@ -190,7 +190,7 @@ public class SourceGrammar extends Grammar {
             throw new IllegalStateException("Unexpected parser type: " + options.getParserType());
         }
 
-        CompiledGrammar compiled = getCompiledGrammar(parserType, seed);
+        ParserGrammar compiled = getCompiledGrammar(parserType, seed);
         if (parserType == ParserType.Earley) {
             return new EarleyParser(compiled, options);
         } else {

--- a/src/main/java/org/nineml/coffeegrinder/parser/State.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/State.java
@@ -175,7 +175,7 @@ public class State {
         return position == rhs.length;
     }
 
-    public Set<Symbol> getFirst(CompiledGrammar grammar) {
+    public Set<Symbol> getFirst(ParserGrammar grammar) {
         if (firstSet == null) {
             firstSet = new HashSet<>();
             int spos = position;

--- a/src/main/java/org/nineml/coffeegrinder/parser/XEarleyParser.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/XEarleyParser.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public class XEarleyParser {
     public static final String logcategory = "Parser";
-    public final CompiledGrammar grammar;
+    public final ParserGrammar grammar;
     private final NonterminalSymbol seedPrime;
     private final ArrayList<State> grammarSlots;
     private final EarleyChart S = new EarleyChart();
@@ -28,7 +28,7 @@ public class XEarleyParser {
         SourceGrammar modifiedGrammar = new SourceGrammar(sourceGrammar);
         seedPrime = modifiedGrammar.getNonterminal("$$");
         modifiedGrammar.addRule(seedPrime, seed);
-        grammar = new CompiledGrammar(modifiedGrammar, ParserType.Earley, seedPrime);
+        grammar = new ParserGrammar(modifiedGrammar, ParserType.Earley, seedPrime);
 
         bsr = new BinarySubtree(grammar.getSeed(), options);
 

--- a/src/main/java/org/nineml/coffeegrinder/parser/package-info.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/package-info.java
@@ -3,7 +3,7 @@
  *
  * <p>In outline:</p>
  * <ul>
- *     <li>Create a {@link org.nineml.coffeegrinder.parser.CompiledGrammar Grammar}.</li>
+ *     <li>Create a {@link org.nineml.coffeegrinder.parser.ParserGrammar Grammar}.</li>
  *     <li>Use the grammar to create {@link org.nineml.coffeegrinder.parser.NonterminalSymbol NonterminalSymbols}.</li>
  *     <li>Use the grammar (or {@link org.nineml.coffeegrinder.parser.Rule Rule} directly) to create rules and add them to the grammar.</li>
  *     <li>Create an {@link org.nineml.coffeegrinder.parser.EarleyParser EarleyParser} from the grammar.</li>

--- a/src/main/java/org/nineml/coffeegrinder/util/GrammarCompiler.java
+++ b/src/main/java/org/nineml/coffeegrinder/util/GrammarCompiler.java
@@ -26,8 +26,8 @@ import java.util.*;
  * can be loaded with the {@link #parse} method.</p>
  */
 public class GrammarCompiler {
-    private static final String formatVersion="0.9.5";
-    private static final char nameEscape = 'ǝ';
+    private static final String formatVersion="1.99.8";
+    private static final char nameEscape = 'E';
     private static final String NS = "http://nineml.org/coffeegrinder/ns/grammar/compiled";
     private static final HashMap<Character,String> entities = new HashMap<>();
     static {
@@ -104,6 +104,7 @@ public class GrammarCompiler {
         initializeDigest();
         agroups.clear();
         sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
         sb.append("<grammar xmlns=\"").append(NS).append("\"");
         sb.append(" version=\"").append(formatVersion).append("\">\n");
 
@@ -222,7 +223,7 @@ public class GrammarCompiler {
             sb.append("</r>\n");
         }
 
-        sb.append("<check Σ=\"");
+        sb.append("<check sum=\"");
         byte[] hash = xdigest.digest();
         for (int pos = hash.length - 8; pos < hash.length; pos++) {
             sb.append(Integer.toString((hash[pos] & 0xff) + 0x100, 16).substring(1));
@@ -574,7 +575,7 @@ public class GrammarCompiler {
                         sb.append(Integer.toString((hash[pos] & 0xff) + 0x100, 16).substring(1));
                     }
                     String checksum = sb.toString();
-                    String expected = attributes.getValue("Σ");
+                    String expected = attributes.getValue("sum");
                     if (!checksum.equals(expected)) {
                         throw CompilerException.checkumFailed();
                     }

--- a/src/main/java/org/nineml/coffeegrinder/util/GrammarCompiler.java
+++ b/src/main/java/org/nineml/coffeegrinder/util/GrammarCompiler.java
@@ -83,7 +83,7 @@ public class GrammarCompiler {
      * @param grammar the grammar to compile
      * @return a "compiled" string format of the grammar
      */
-    public String compile(CompiledGrammar grammar) {
+    public String compile(ParserGrammar grammar) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);
         compile(grammar, ps);
@@ -100,7 +100,7 @@ public class GrammarCompiler {
      * @param grammar the grammar to compile
      * @param ps the print stream where the compiled grammar is written
      */
-    public void compile(CompiledGrammar grammar, PrintStream ps) {
+    public void compile(ParserGrammar grammar, PrintStream ps) {
         initializeDigest();
         agroups.clear();
         sb = new StringBuilder();
@@ -425,7 +425,7 @@ public class GrammarCompiler {
     }
 
     /**
-     * Parse a compiled grammar to reconstruct a {@link CompiledGrammar} object.
+     * Parse a compiled grammar to reconstruct a {@link ParserGrammar} object.
      * @param compiled A file containing a grammar
      * @return The grammar stored in the compiled file
      * @throws GrammarException if there are errors in the compiled form
@@ -440,7 +440,7 @@ public class GrammarCompiler {
     }
 
     /**
-     * Parse a compiled grammar to reconstruct a {@link CompiledGrammar} object.
+     * Parse a compiled grammar to reconstruct a {@link ParserGrammar} object.
      * @param compiled A file containing a grammar
      * @param systemId the systemId of the grammar file
      * @return The grammar stored in the compiled file
@@ -458,7 +458,7 @@ public class GrammarCompiler {
     }
 
     /**
-     * Parse a compiled grammar to reconstruct a {@link CompiledGrammar} object.
+     * Parse a compiled grammar to reconstruct a {@link ParserGrammar} object.
      * @param input A string containing a compiled grammar
      * @return The grammar stored in the compiled file
      * @throws GrammarException if there are errors in the compiled form

--- a/src/test/java/org/nineml/coffeegrinder/GrammarTest.java
+++ b/src/test/java/org/nineml/coffeegrinder/GrammarTest.java
@@ -284,7 +284,7 @@ public class GrammarTest {
         HygieneReport report = grammar.getHygieneReport(_S);
         Assert.assertEquals(0, logger.warncount);
 
-        CompiledGrammar cgrammar = grammar.getCompiledGrammar(_S);
+        ParserGrammar cgrammar = grammar.getCompiledGrammar(_S);
         report = cgrammar.getHygieneReport();
         Assert.assertEquals(1, logger.warncount);
 

--- a/src/test/resources/css.cxml
+++ b/src/test/resources/css.cxml
@@ -1,12 +1,13 @@
-<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="0.9.5">
-<meta name='coffeepot-version' value='1.99.4b'/>
-<meta name='date' value='2022-06-25T08:26:48Z'/>
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="1.99.8">
+<meta name='coffeepot-version' value='1.99.8'/>
+<meta name='date' value='2022-06-30T17:00:29Z'/>
 <meta name='uri' value='file:/Volumes/Projects/nineml/grinder/src/test/resources/css.ixml'/>
-<ag xml:id="g1" name="$$" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g1" name="$$" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g2" name="css" mark="^"/>
 <r n="$$" a="p" ag="g1"><nt n="css" ag="g2"/></r>
 <ag xml:id="g3" name="S" mark="-"/>
-<ag xml:id="g4" name="$4_rule-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g4" name="$4_rule-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="css" ag="g2"><nt n="S" ag="g3"/><nt n="$4_rule-plus" a="p" ag="g4"/></r>
 <ag xml:id="g5" name="rule" mark="^"/>
 <ag xml:id="g6" name="selector" mark="^"/>
@@ -14,7 +15,7 @@
 <r n="rule" ag="g5"><nt n="selector" ag="g6"/><nt n="block" ag="g7"/></r>
 <ag xml:id="g8" tmark="-"/>
 <ag xml:id="g9"/>
-<ag xml:id="g10" name="$2_property-star-sep-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g10" name="$2_property-star-sep-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="block" ag="g7"><t ag="g8"><c ag="g9" v="{"/></t><nt n="S" ag="g3"/><nt n="$2_property-star-sep-option" a="p" ag="g10"/><t ag="g8"><c ag="g9" v="}"/></t><nt n="S" ag="g3"/></r>
 <ag xml:id="g11" name="property" mark="^"/>
 <ag xml:id="g12" name="name" mark="@"/>
@@ -24,44 +25,44 @@
 <r n="property" ag="g11"><nt n="empty" ag="g14"/></r>
 <ag xml:id="g15" name="name" mark="^"/>
 <r n="selector" ag="g6"><nt n="name" ag="g15"/><nt n="S" ag="g3"/></r>
-<ag xml:id="g16" name="$5_letter-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g16" name="$5_letter-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="name" ag="g15"><nt n="$5_letter-plus" a="p" ag="g16"/></r>
 <ag xml:id="g17" name="letter" mark="-"/>
 <ag xml:id="g18" tmark="^"/>
 <r n="letter" ag="g17"><t ag="g18"><cs ag="g9" inclusion="'a'-'z';&quot;-&quot;"/></t></r>
 <ag xml:id="g19" name="digit" mark="^"/>
 <r n="digit" ag="g19"><t ag="g18"><cs ag="g9" inclusion="'0'-'9'"/></t></r>
-<ag xml:id="g20" name="$1_alt" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g20" name="$1_alt" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="value" ag="g13"><nt n="$1_alt" a="p" ag="g20"/><nt n="S" ag="g3"/></r>
 <ag xml:id="g21" name="number" mark="^"/>
-<ag xml:id="g22" name="$6_digit-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g22" name="$6_digit-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="number" ag="g21"><nt n="$6_digit-plus" a="p" ag="g22"/></r>
 <r n="empty" ag="g14"></r>
-<ag xml:id="g23" name="$7_star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g23" name="$7_star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="S" ag="g3"><nt n="$7_star" a="p" ag="g23"/></r>
 <r n="$1_alt" a="p" ag="g20"><nt n="name" ag="g12"/></r>
 <ag xml:id="g24" name="number" mark="@"/>
 <r n="$1_alt" a="p" ag="g20"><nt n="number" ag="g24"/></r>
 <r n="$2_property-star-sep-option" a="p" ag="g10"></r>
-<ag xml:id="g25" name="$3_property-plus-sep" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g25" name="$3_property-plus-sep" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$2_property-star-sep-option" a="p" ag="g10"><nt n="$3_property-plus-sep" a="p" ag="g25"/></r>
-<ag xml:id="g26" name="$8_L;-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g26" name="$8_L;-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$3_property-plus-sep" a="p" ag="g25"><nt n="property" ag="g11"/><nt n="$8_L;-star" a="p" ag="g26"/></r>
-<ag xml:id="g27" name="$9_rule-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g27" name="$9_rule-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$4_rule-plus" a="p" ag="g4"><nt n="rule" ag="g5"/><nt n="$9_rule-star" a="p" ag="g27"/></r>
-<ag xml:id="g28" name="$10_letter-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g28" name="$10_letter-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$5_letter-plus" a="p" ag="g16"><nt n="letter" ag="g17"/><nt n="$10_letter-star" a="p" ag="g28"/></r>
-<ag xml:id="g29" name="$11_digit-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g29" name="$11_digit-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$6_digit-plus" a="p" ag="g22"><nt n="digit" ag="g19"/><nt n="$11_digit-star" a="p" ag="g29"/></r>
-<ag xml:id="g30" name="$12_option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g30" name="$12_option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$7_star" a="p" ag="g23"><nt n="$12_option" a="p" ag="g30"/></r>
-<ag xml:id="g31" name="$13_L;-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g31" name="$13_L;-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$8_L;-star" a="p" ag="g26"><nt n="$13_L;-option" a="p" ag="g31"/></r>
-<ag xml:id="g32" name="$14_rule-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g32" name="$14_rule-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$9_rule-star" a="p" ag="g27"><nt n="$14_rule-option" a="p" ag="g32"/></r>
-<ag xml:id="g33" name="$15_letter-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g33" name="$15_letter-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$10_letter-star" a="p" ag="g28"><nt n="$15_letter-option" a="p" ag="g33"/></r>
-<ag xml:id="g34" name="$16_digit-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g34" name="$16_digit-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$11_digit-star" a="p" ag="g29"><nt n="$16_digit-option" a="p" ag="g34"/></r>
 <r n="$12_option" a="p" ag="g30"></r>
 <r n="$12_option" a="p" ag="g30"><t ag="g8"><cs ag="g9" inclusion="&quot; &quot;;'&#xa;';'&#xd;'"/></t><nt n="$7_star" a="p" ag="g23"/></r>
@@ -73,6 +74,6 @@
 <r n="$15_letter-option" a="p" ag="g33"><nt n="letter" ag="g17"/><nt n="$10_letter-star" a="p" ag="g28"/></r>
 <r n="$16_digit-option" a="p" ag="g34"></r>
 <r n="$16_digit-option" a="p" ag="g34"><nt n="digit" ag="g19"/><nt n="$11_digit-star" a="p" ag="g29"/></r>
-<check Σ="722fdbe458512891"/>
+<check sum="036fe70135c6cd02"/>
 </grammar>
 

--- a/src/test/resources/hash.cxml
+++ b/src/test/resources/hash.cxml
@@ -1,11 +1,14 @@
-<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="0.9.5">
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="1.99.8">
 <meta name='Date' value='2022-01-30'/>
 <meta name='Source' value='Invisible XML test suite'/>
+<meta name='coffeepot-version' value='1.99.8'/>
+<meta name='date' value='2022-06-30T17:00:30Z'/>
 <meta name='uri' value='file:/Volumes/Projects/nineml/grinder/src/test/resources/hash.ixml'/>
-<ag xml:id="g1" name="$$" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g1" name="$$" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g2" name="hashes" mark="^"/>
 <r n="$$" a="p" ag="g1"><nt n="hashes" ag="g2"/></r>
-<ag xml:id="g3" name="$1_hash-star-sep-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g3" name="$1_hash-star-sep-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g4" tmark="^"/>
 <ag xml:id="g5"/>
 <r n="hashes" ag="g2"><nt n="$1_hash-star-sep-option" a="p" ag="g3"/><t ag="g4"><c ag="g5" v="."/></t></r>
@@ -13,33 +16,33 @@
 <ag xml:id="g7" name="d6" mark="@"/>
 <r n="hash" ag="g6"><t ag="g4"><c ag="g5" v="#"/></t><nt n="d6" ag="g7"/></r>
 <ag xml:id="g8" name="d" mark="-"/>
-<ag xml:id="g9" name="$10_d-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g9" name="$10_d-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="d6" ag="g7"><nt n="d" ag="g8"/><nt n="$10_d-option" a="p" ag="g9"/></r>
 <r n="d" ag="g8"><t ag="g4"><cs ag="g5" inclusion="'0'-'9'"/></t></r>
 <ag xml:id="g10" name="S" mark="-"/>
-<ag xml:id="g11" name="$3_L0x20-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g11" name="$3_L0x20-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="S" ag="g10"><nt n="$3_L0x20-plus" a="p" ag="g11"/></r>
 <r n="$1_hash-star-sep-option" a="p" ag="g3"></r>
-<ag xml:id="g12" name="$2_hash-plus-sep" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g12" name="$2_hash-plus-sep" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$1_hash-star-sep-option" a="p" ag="g3"><nt n="$2_hash-plus-sep" a="p" ag="g12"/></r>
-<ag xml:id="g13" name="$4_S-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g13" name="$4_S-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$2_hash-plus-sep" a="p" ag="g12"><nt n="hash" ag="g6"/><nt n="$4_S-star" a="p" ag="g13"/></r>
-<ag xml:id="g14" name="$5_L0x20-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g14" name="$5_L0x20-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$3_L0x20-plus" a="p" ag="g11"><t ag="g4"><c ag="g5" v=" "/></t><nt n="$5_L0x20-star" a="p" ag="g14"/></r>
-<ag xml:id="g15" name="$11_S-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g15" name="$11_S-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$4_S-star" a="p" ag="g13"><nt n="$11_S-option" a="p" ag="g15"/></r>
-<ag xml:id="g16" name="$12_L0x20-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g16" name="$12_L0x20-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$5_L0x20-star" a="p" ag="g14"><nt n="$12_L0x20-option" a="p" ag="g16"/></r>
-<ag xml:id="g17" name="$6_d-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g17" name="$6_d-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$6_d-option" a="p" ag="g17"></r>
 <r n="$6_d-option" a="p" ag="g17"><nt n="d" ag="g8"/></r>
-<ag xml:id="g18" name="$7_d-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g18" name="$7_d-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$7_d-option" a="p" ag="g18"></r>
 <r n="$7_d-option" a="p" ag="g18"><nt n="d" ag="g8"/><nt n="$6_d-option" a="p" ag="g17"/></r>
-<ag xml:id="g19" name="$8_d-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g19" name="$8_d-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$8_d-option" a="p" ag="g19"></r>
 <r n="$8_d-option" a="p" ag="g19"><nt n="d" ag="g8"/><nt n="$7_d-option" a="p" ag="g18"/></r>
-<ag xml:id="g20" name="$9_d-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g20" name="$9_d-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$9_d-option" a="p" ag="g20"></r>
 <r n="$9_d-option" a="p" ag="g20"><nt n="d" ag="g8"/><nt n="$8_d-option" a="p" ag="g19"/></r>
 <r n="$10_d-option" a="p" ag="g9"></r>
@@ -48,5 +51,5 @@
 <r n="$11_S-option" a="p" ag="g15"><nt n="S" ag="g10"/><nt n="hash" ag="g6"/><nt n="$4_S-star" a="p" ag="g13"/></r>
 <r n="$12_L0x20-option" a="p" ag="g16"></r>
 <r n="$12_L0x20-option" a="p" ag="g16"><t ag="g4"><c ag="g5" v=" "/></t><nt n="$5_L0x20-star" a="p" ag="g14"/></r>
-<check Σ="03782238a47393e4"/>
+<check sum="d44561307da20d07"/>
 </grammar>

--- a/src/test/resources/ixml.cxml
+++ b/src/test/resources/ixml.cxml
@@ -1,18 +1,19 @@
-<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="0.9.5">
-<meta name='coffeepot-version' value='1.99.4b'/>
-<meta name='date' value='2022-06-25T08:28:15Z'/>
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="1.99.8">
+<meta name='coffeepot-version' value='1.99.8'/>
+<meta name='date' value='2022-06-30T17:02:26Z'/>
 <meta name='uri' value='file:/Volumes/Projects/nineml/filter/src/main/resources/org/nineml/coffeefilter/ixml.ixml'/>
-<ag xml:id="g1" name="$$" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g1" name="$$" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g2" name="ixml" mark="^"/>
 <r n="$$" a="p" ag="g1"><nt n="ixml" ag="g2"/></r>
 <ag xml:id="g3" name="s" mark="-"/>
-<ag xml:id="g4" name="$28_prolog-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
-<ag xml:id="g5" name="$9_rule-plus-sep" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g4" name="$28_prolog-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
+<ag xml:id="g5" name="$9_rule-plus-sep" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="ixml" ag="g2"><nt n="s" ag="g3"/><nt n="$28_prolog-option" a="p" ag="g4"/><nt n="$9_rule-plus-sep" a="p" ag="g5"/><nt n="s" ag="g3"/></r>
-<ag xml:id="g6" name="$17_$1_alt-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g6" name="$17_$1_alt-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="s" ag="g3"><nt n="$17_$1_alt-star" a="p" ag="g6"/></r>
 <ag xml:id="g7" name="RS" mark="-"/>
-<ag xml:id="g8" name="$13_$2_alt-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g8" name="$13_$2_alt-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="RS" ag="g7"><nt n="$13_$2_alt-plus" a="p" ag="g8"/></r>
 <ag xml:id="g9" name="whitespace" mark="-"/>
 <ag xml:id="g10" tmark="-"/>
@@ -28,7 +29,7 @@
 <r n="lf" ag="g13"><t ag="g10"><c ag="g11" v="&#xa;"/></t></r>
 <r n="cr" ag="g14"><t ag="g10"><c ag="g11" v="&#xd;"/></t></r>
 <ag xml:id="g15" name="comment" mark="^"/>
-<ag xml:id="g16" name="$18_$3_alt-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g16" name="$18_$3_alt-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="comment" ag="g15"><t ag="g10"><c ag="g11" v="{"/></t><nt n="$18_$3_alt-star" a="p" ag="g16"/><t ag="g10"><c ag="g11" v="}"/></t></r>
 <ag xml:id="g17" name="cchar" mark="-"/>
 <ag xml:id="g18" tmark="^"/>
@@ -39,17 +40,17 @@
 <ag xml:id="g21" name="string" mark="@"/>
 <r n="version" ag="g20"><t ag="g10"><c ag="g11" v="i"/></t><t ag="g10"><c ag="g11" v="x"/></t><t ag="g10"><c ag="g11" v="m"/></t><t ag="g10"><c ag="g11" v="l"/></t><nt n="RS" ag="g7"/><t ag="g10"><c ag="g11" v="v"/></t><t ag="g10"><c ag="g11" v="e"/></t><t ag="g10"><c ag="g11" v="r"/></t><t ag="g10"><c ag="g11" v="s"/></t><t ag="g10"><c ag="g11" v="i"/></t><t ag="g10"><c ag="g11" v="o"/></t><t ag="g10"><c ag="g11" v="n"/></t><nt n="RS" ag="g7"/><nt n="string" ag="g21"/><nt n="s" ag="g3"/><t ag="g10"><c ag="g11" v="."/></t></r>
 <ag xml:id="g22" name="rule" mark="^"/>
-<ag xml:id="g23" name="$29_mark-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g23" name="$29_mark-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g24" name="name" mark="@"/>
 <ag xml:id="g25" name="alts" mark="-"/>
 <r n="rule" ag="g22"><nt n="$29_mark-option" a="p" ag="g23"/><nt n="name" ag="g24"/><nt n="s" ag="g3"/><t ag="g10"><cs ag="g11" inclusion="&quot;:=&quot;"/></t><nt n="s" ag="g3"/><nt n="alts" ag="g25"/><t ag="g10"><c ag="g11" v="."/></t></r>
 <ag xml:id="g26" name="mark" mark="@"/>
 <r n="mark" ag="g26"><t ag="g18"><cs ag="g11" inclusion="&quot;@-^&quot;"/></t></r>
 <ag xml:id="g27" name="alts" mark="^"/>
-<ag xml:id="g28" name="$10_alt-plus-sep" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g28" name="$10_alt-plus-sep" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="alts" ag="g27"><nt n="$10_alt-plus-sep" a="p" ag="g28"/></r>
 <ag xml:id="g29" name="alt" mark="^"/>
-<ag xml:id="g30" name="$7_term-star-sep-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g30" name="$7_term-star-sep-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="alt" ag="g29"><nt n="$7_term-star-sep-option" a="p" ag="g30"/></r>
 <ag xml:id="g31" name="term" mark="-"/>
 <ag xml:id="g32" name="factor" mark="-"/>
@@ -67,17 +68,17 @@
 <ag xml:id="g38" name="insertion" mark="^"/>
 <r n="factor" ag="g32"><nt n="insertion" ag="g38"/></r>
 <r n="factor" ag="g32"><t ag="g10"><c ag="g11" v="("/></t><nt n="s" ag="g3"/><nt n="alts" ag="g27"/><t ag="g10"><c ag="g11" v=")"/></t><nt n="s" ag="g3"/></r>
-<ag xml:id="g39" name="$4_alt" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g39" name="$4_alt" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="repeat0" ag="g34"><nt n="factor" ag="g32"/><nt n="$4_alt" a="p" ag="g39"/></r>
-<ag xml:id="g40" name="$5_alt" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g40" name="$5_alt" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="repeat1" ag="g35"><nt n="factor" ag="g32"/><nt n="$5_alt" a="p" ag="g40"/></r>
 <r n="option" ag="g33"><nt n="factor" ag="g32"/><t ag="g10"><c ag="g11" v="?"/></t><nt n="s" ag="g3"/></r>
 <ag xml:id="g41" name="sep" mark="^"/>
 <r n="sep" ag="g41"><nt n="factor" ag="g32"/></r>
-<ag xml:id="g42" name="$30_mark-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g42" name="$30_mark-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="nonterminal" ag="g37"><nt n="$30_mark-option" a="p" ag="g42"/><nt n="name" ag="g24"/><nt n="s" ag="g3"/></r>
 <ag xml:id="g43" name="namestart" mark="-"/>
-<ag xml:id="g44" name="$19_namefollower-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g44" name="$19_namefollower-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="name" ag="g24"><nt n="namestart" ag="g43"/><nt n="$19_namefollower-star" a="p" ag="g44"/></r>
 <r n="namestart" ag="g43"><t ag="g18"><cs ag="g11" inclusion="&quot;_&quot;;L"/></t></r>
 <ag xml:id="g45" name="namefollower" mark="-"/>
@@ -91,13 +92,13 @@
 <r n="literal" ag="g46"><nt n="quoted" ag="g48"/></r>
 <ag xml:id="g49" name="encoded" mark="-"/>
 <r n="literal" ag="g46"><nt n="encoded" ag="g49"/></r>
-<ag xml:id="g50" name="$31_tmark-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g50" name="$31_tmark-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="quoted" ag="g48"><nt n="$31_tmark-option" a="p" ag="g50"/><nt n="string" ag="g21"/><nt n="s" ag="g3"/></r>
 <ag xml:id="g51" name="tmark" mark="@"/>
 <r n="tmark" ag="g51"><t ag="g18"><cs ag="g11" inclusion="&quot;-^&quot;"/></t></r>
-<ag xml:id="g52" name="$14_dchar-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g52" name="$14_dchar-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="string" ag="g21"><t ag="g10"><c ag="g11" v="&quot;"/></t><nt n="$14_dchar-plus" a="p" ag="g52"/><t ag="g10"><c ag="g11" v="&quot;"/></t></r>
-<ag xml:id="g53" name="$15_schar-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g53" name="$15_schar-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="string" ag="g21"><t ag="g10"><c ag="g11" v="'"/></t><nt n="$15_schar-plus" a="p" ag="g53"/><t ag="g10"><c ag="g11" v="'"/></t></r>
 <ag xml:id="g54" name="dchar" mark="^"/>
 <r n="dchar" ag="g54"><t ag="g18"><cs ag="g11" exclusion="&quot;&amp;quot;&quot;;'&#xa;';'&#xd;'"/></t></r>
@@ -105,21 +106,21 @@
 <ag xml:id="g55" name="schar" mark="^"/>
 <r n="schar" ag="g55"><t ag="g18"><cs ag="g11" exclusion="&quot;'&quot;;'&#xa;';'&#xd;'"/></t></r>
 <r n="schar" ag="g55"><t ag="g18"><c ag="g11" v="'"/></t><t ag="g10"><c ag="g11" v="'"/></t></r>
-<ag xml:id="g56" name="$32_tmark-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g56" name="$32_tmark-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g57" name="hex" mark="@"/>
 <r n="encoded" ag="g49"><nt n="$32_tmark-option" a="p" ag="g56"/><t ag="g10"><c ag="g11" v="#"/></t><nt n="hex" ag="g57"/><nt n="s" ag="g3"/></r>
-<ag xml:id="g58" name="$16_plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g58" name="$16_plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="hex" ag="g57"><nt n="$16_plus" a="p" ag="g58"/></r>
 <ag xml:id="g59" name="inclusion" mark="^"/>
 <r n="charset" ag="g47"><nt n="inclusion" ag="g59"/></r>
 <ag xml:id="g60" name="exclusion" mark="^"/>
 <r n="charset" ag="g47"><nt n="exclusion" ag="g60"/></r>
-<ag xml:id="g61" name="$33_tmark-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g61" name="$33_tmark-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g62" name="set" mark="-"/>
 <r n="inclusion" ag="g59"><nt n="$33_tmark-option" a="p" ag="g61"/><nt n="set" ag="g62"/></r>
-<ag xml:id="g63" name="$34_tmark-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g63" name="$34_tmark-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="exclusion" ag="g60"><nt n="$34_tmark-option" a="p" ag="g63"/><t ag="g10"><c ag="g11" v="~"/></t><nt n="s" ag="g3"/><nt n="set" ag="g62"/></r>
-<ag xml:id="g64" name="$8_member-star-sep-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g64" name="$8_member-star-sep-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="set" ag="g62"><t ag="g10"><c ag="g11" v="["/></t><nt n="s" ag="g3"/><nt n="$8_member-star-sep-option" a="p" ag="g64"/><t ag="g10"><c ag="g11" v="]"/></t><nt n="s" ag="g3"/></r>
 <ag xml:id="g65" name="member" mark="^"/>
 <r n="member" ag="g65"><nt n="string" ag="g21"/></r>
@@ -140,20 +141,20 @@
 <ag xml:id="g71" name="code" mark="@"/>
 <r n="class" ag="g67"><nt n="code" ag="g71"/></r>
 <ag xml:id="g72" name="capital" mark="-"/>
-<ag xml:id="g73" name="$35_letter-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g73" name="$35_letter-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="code" ag="g71"><nt n="capital" ag="g72"/><nt n="$35_letter-option" a="p" ag="g73"/></r>
 <r n="capital" ag="g72"><t ag="g18"><cs ag="g11" inclusion="'A'-'Z'"/></t></r>
 <ag xml:id="g74" name="letter" mark="-"/>
 <r n="letter" ag="g74"><t ag="g18"><cs ag="g11" inclusion="'a'-'z'"/></t></r>
-<ag xml:id="g75" name="$6_alt" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g75" name="$6_alt" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="insertion" ag="g38"><t ag="g10"><c ag="g11" v="+"/></t><nt n="s" ag="g3"/><nt n="$6_alt" a="p" ag="g75"/><nt n="s" ag="g3"/></r>
-<ag xml:id="g76" name="$1_alt" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g76" name="$1_alt" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$1_alt" a="p" ag="g76"><nt n="whitespace" ag="g9"/></r>
 <r n="$1_alt" a="p" ag="g76"><nt n="comment" ag="g15"/></r>
-<ag xml:id="g77" name="$2_alt" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g77" name="$2_alt" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$2_alt" a="p" ag="g77"><nt n="whitespace" ag="g9"/></r>
 <r n="$2_alt" a="p" ag="g77"><nt n="comment" ag="g15"/></r>
-<ag xml:id="g78" name="$3_alt" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g78" name="$3_alt" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$3_alt" a="p" ag="g78"><nt n="cchar" ag="g17"/></r>
 <r n="$3_alt" a="p" ag="g78"><nt n="comment" ag="g15"/></r>
 <r n="$4_alt" a="p" ag="g39"><t ag="g10"><c ag="g11" v="*"/></t><nt n="s" ag="g3"/></r>
@@ -163,48 +164,48 @@
 <r n="$6_alt" a="p" ag="g75"><nt n="string" ag="g21"/></r>
 <r n="$6_alt" a="p" ag="g75"><t ag="g10"><c ag="g11" v="#"/></t><nt n="hex" ag="g57"/></r>
 <r n="$7_term-star-sep-option" a="p" ag="g30"></r>
-<ag xml:id="g79" name="$11_term-plus-sep" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g79" name="$11_term-plus-sep" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$7_term-star-sep-option" a="p" ag="g30"><nt n="$11_term-plus-sep" a="p" ag="g79"/></r>
 <r n="$8_member-star-sep-option" a="p" ag="g64"></r>
-<ag xml:id="g80" name="$12_member-plus-sep" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g80" name="$12_member-plus-sep" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$8_member-star-sep-option" a="p" ag="g64"><nt n="$12_member-plus-sep" a="p" ag="g80"/></r>
-<ag xml:id="g81" name="$20_RS-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g81" name="$20_RS-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$9_rule-plus-sep" a="p" ag="g5"><nt n="rule" ag="g22"/><nt n="$20_RS-star" a="p" ag="g81"/></r>
-<ag xml:id="g82" name="$21_star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g82" name="$21_star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$10_alt-plus-sep" a="p" ag="g28"><nt n="alt" ag="g29"/><nt n="$21_star" a="p" ag="g82"/></r>
-<ag xml:id="g83" name="$22_L,-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g83" name="$22_L,-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$11_term-plus-sep" a="p" ag="g79"><nt n="term" ag="g31"/><nt n="$22_L,-star" a="p" ag="g83"/></r>
-<ag xml:id="g84" name="$23_star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g84" name="$23_star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$12_member-plus-sep" a="p" ag="g80"><nt n="member" ag="g65"/><nt n="s" ag="g3"/><nt n="$23_star" a="p" ag="g84"/></r>
-<ag xml:id="g85" name="$24_$2_alt-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g85" name="$24_$2_alt-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$13_$2_alt-plus" a="p" ag="g8"><nt n="$2_alt" a="p" ag="g77"/><nt n="$24_$2_alt-star" a="p" ag="g85"/></r>
-<ag xml:id="g86" name="$25_dchar-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g86" name="$25_dchar-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$14_dchar-plus" a="p" ag="g52"><nt n="dchar" ag="g54"/><nt n="$25_dchar-star" a="p" ag="g86"/></r>
-<ag xml:id="g87" name="$26_schar-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g87" name="$26_schar-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$15_schar-plus" a="p" ag="g53"><nt n="schar" ag="g55"/><nt n="$26_schar-star" a="p" ag="g87"/></r>
-<ag xml:id="g88" name="$27_star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g88" name="$27_star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$16_plus" a="p" ag="g58"><t ag="g18"><cs ag="g11" inclusion="'0'-'9';'a'-'f';'A'-'F'"/></t><nt n="$27_star" a="p" ag="g88"/></r>
-<ag xml:id="g89" name="$36_$1_alt-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g89" name="$36_$1_alt-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$17_$1_alt-star" a="p" ag="g6"><nt n="$36_$1_alt-option" a="p" ag="g89"/></r>
-<ag xml:id="g90" name="$37_$3_alt-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g90" name="$37_$3_alt-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$18_$3_alt-star" a="p" ag="g16"><nt n="$37_$3_alt-option" a="p" ag="g90"/></r>
-<ag xml:id="g91" name="$38_namefollower-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g91" name="$38_namefollower-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$19_namefollower-star" a="p" ag="g44"><nt n="$38_namefollower-option" a="p" ag="g91"/></r>
-<ag xml:id="g92" name="$39_RS-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g92" name="$39_RS-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$20_RS-star" a="p" ag="g81"><nt n="$39_RS-option" a="p" ag="g92"/></r>
-<ag xml:id="g93" name="$40_option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g93" name="$40_option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$21_star" a="p" ag="g82"><nt n="$40_option" a="p" ag="g93"/></r>
-<ag xml:id="g94" name="$41_L,-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g94" name="$41_L,-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$22_L,-star" a="p" ag="g83"><nt n="$41_L,-option" a="p" ag="g94"/></r>
-<ag xml:id="g95" name="$42_option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g95" name="$42_option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$23_star" a="p" ag="g84"><nt n="$42_option" a="p" ag="g95"/></r>
-<ag xml:id="g96" name="$43_$2_alt-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g96" name="$43_$2_alt-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$24_$2_alt-star" a="p" ag="g85"><nt n="$43_$2_alt-option" a="p" ag="g96"/></r>
-<ag xml:id="g97" name="$44_dchar-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g97" name="$44_dchar-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$25_dchar-star" a="p" ag="g86"><nt n="$44_dchar-option" a="p" ag="g97"/></r>
-<ag xml:id="g98" name="$45_schar-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g98" name="$45_schar-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$26_schar-star" a="p" ag="g87"><nt n="$45_schar-option" a="p" ag="g98"/></r>
-<ag xml:id="g99" name="$46_option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g99" name="$46_option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$27_star" a="p" ag="g88"><nt n="$46_option" a="p" ag="g99"/></r>
 <r n="$28_prolog-option" a="p" ag="g4"></r>
 <r n="$28_prolog-option" a="p" ag="g4"><nt n="prolog" ag="g19"/></r>
@@ -244,6 +245,6 @@
 <r n="$45_schar-option" a="p" ag="g98"><nt n="schar" ag="g55"/><nt n="$26_schar-star" a="p" ag="g87"/></r>
 <r n="$46_option" a="p" ag="g99"></r>
 <r n="$46_option" a="p" ag="g99"><t ag="g18"><cs ag="g11" inclusion="'0'-'9';'a'-'f';'A'-'F'"/></t><nt n="$27_star" a="p" ag="g88"/></r>
-<check Σ="5b0967b38ca340af"/>
+<check sum="9ea0117f4b569e26"/>
 </grammar>
 

--- a/src/test/resources/month.cxml
+++ b/src/test/resources/month.cxml
@@ -1,8 +1,9 @@
-<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="0.9.5">
-<meta name='coffeepot-version' value='1.99.4b'/>
-<meta name='date' value='2022-06-25T08:26:44Z'/>
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="1.99.8">
+<meta name='coffeepot-version' value='1.99.8'/>
+<meta name='date' value='2022-06-30T17:00:26Z'/>
 <meta name='uri' value='file:/Volumes/Projects/nineml/grinder/src/test/resources/month.ixml'/>
-<ag xml:id="g1" name="$$" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g1" name="$$" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g2" name="month" mark="^"/>
 <r n="$$" a="p" ag="g1"><nt n="month" ag="g2"/></r>
 <ag xml:id="g3" tmark="^"/>
@@ -19,6 +20,6 @@
 <r n="month" ag="g2"><t ag="g3"><c ag="g4" v="O"/></t><t ag="g3"><c ag="g4" v="c"/></t><t ag="g3"><c ag="g4" v="t"/></t><t ag="g3"><c ag="g4" v="o"/></t><t ag="g3"><c ag="g4" v="b"/></t><t ag="g3"><c ag="g4" v="e"/></t><t ag="g3"><c ag="g4" v="r"/></t></r>
 <r n="month" ag="g2"><t ag="g3"><c ag="g4" v="N"/></t><t ag="g3"><c ag="g4" v="o"/></t><t ag="g3"><c ag="g4" v="v"/></t><t ag="g3"><c ag="g4" v="e"/></t><t ag="g3"><c ag="g4" v="m"/></t><t ag="g3"><c ag="g4" v="b"/></t><t ag="g3"><c ag="g4" v="e"/></t><t ag="g3"><c ag="g4" v="r"/></t></r>
 <r n="month" ag="g2"><t ag="g3"><c ag="g4" v="D"/></t><t ag="g3"><c ag="g4" v="e"/></t><t ag="g3"><c ag="g4" v="c"/></t><t ag="g3"><c ag="g4" v="e"/></t><t ag="g3"><c ag="g4" v="m"/></t><t ag="g3"><c ag="g4" v="b"/></t><t ag="g3"><c ag="g4" v="e"/></t><t ag="g3"><c ag="g4" v="r"/></t></r>
-<check Σ="c96c0f9b4c609325"/>
+<check sum="1da9796d67502ec5"/>
 </grammar>
 

--- a/src/test/resources/program.cxml
+++ b/src/test/resources/program.cxml
@@ -1,8 +1,9 @@
-<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="0.9.5">
-<meta name='coffeepot-version' value='1.99.4b'/>
-<meta name='date' value='2022-06-25T08:26:47Z'/>
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="1.99.8">
+<meta name='coffeepot-version' value='1.99.8'/>
+<meta name='date' value='2022-06-30T17:00:28Z'/>
 <meta name='uri' value='file:/Volumes/Projects/nineml/grinder/src/test/resources/program.ixml'/>
-<ag xml:id="g1" name="$$" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g1" name="$$" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g2" name="program" mark="^"/>
 <r n="$$" a="p" ag="g1"><nt n="program" ag="g2"/></r>
 <ag xml:id="g3" name="block" mark="^"/>
@@ -10,7 +11,7 @@
 <ag xml:id="g4" tmark="^"/>
 <ag xml:id="g5"/>
 <ag xml:id="g6" name="S" mark="-"/>
-<ag xml:id="g7" name="$1_statement-star-sep-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g7" name="$1_statement-star-sep-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="block" ag="g3"><t ag="g4"><c ag="g5" v="{"/></t><nt n="S" ag="g6"/><nt n="$1_statement-star-sep-option" a="p" ag="g7"/><t ag="g4"><c ag="g5" v="}"/></t><nt n="S" ag="g6"/></r>
 <ag xml:id="g8" name="statement" mark="^"/>
 <ag xml:id="g9" name="if-statement" mark="^"/>
@@ -24,7 +25,7 @@
 <r n="statement" ag="g8"><nt n="block" ag="g3"/></r>
 <r n="statement" ag="g8"></r>
 <ag xml:id="g13" name="condition" mark="^"/>
-<ag xml:id="g14" name="$12_else-part-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g14" name="$12_else-part-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="if-statement" ag="g9"><t ag="g4"><c ag="g5" v="i"/></t><t ag="g4"><c ag="g5" v="f"/></t><nt n="S" ag="g6"/><nt n="condition" ag="g13"/><t ag="g4"><c ag="g5" v="t"/></t><t ag="g4"><c ag="g5" v="h"/></t><t ag="g4"><c ag="g5" v="e"/></t><t ag="g4"><c ag="g5" v="n"/></t><nt n="S" ag="g6"/><nt n="statement" ag="g8"/><nt n="$12_else-part-option" a="p" ag="g14"/></r>
 <ag xml:id="g15" name="else-part" mark="^"/>
 <r n="else-part" ag="g15"><t ag="g4"><c ag="g5" v="e"/></t><t ag="g4"><c ag="g5" v="l"/></t><t ag="g4"><c ag="g5" v="s"/></t><t ag="g4"><c ag="g5" v="e"/></t><nt n="S" ag="g6"/><nt n="statement" ag="g8"/></r>
@@ -34,17 +35,17 @@
 <r n="assignment" ag="g11"><nt n="variable" ag="g16"/><t ag="g4"><c ag="g5" v="="/></t><nt n="S" ag="g6"/><nt n="expression" ag="g17"/></r>
 <ag xml:id="g18" name="identifier" mark="^"/>
 <r n="variable" ag="g16"><nt n="identifier" ag="g18"/></r>
-<ag xml:id="g19" name="$2_parameter-star-sep-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g19" name="$2_parameter-star-sep-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="call" ag="g12"><nt n="identifier" ag="g18"/><t ag="g4"><c ag="g5" v="("/></t><nt n="S" ag="g6"/><nt n="$2_parameter-star-sep-option" a="p" ag="g19"/><t ag="g4"><c ag="g5" v=")"/></t><nt n="S" ag="g6"/></r>
 <ag xml:id="g20" name="parameter" mark="^"/>
 <ag xml:id="g21" name="expression" mark="-"/>
 <r n="parameter" ag="g20"><nt n="expression" ag="g21"/></r>
-<ag xml:id="g22" name="$5_letter-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g22" name="$5_letter-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="identifier" ag="g18"><nt n="$5_letter-plus" a="p" ag="g22"/><nt n="S" ag="g6"/></r>
 <r n="expression" ag="g17"><nt n="identifier" ag="g18"/></r>
 <ag xml:id="g23" name="number" mark="^"/>
 <r n="expression" ag="g17"><nt n="number" ag="g23"/></r>
-<ag xml:id="g24" name="$6_digit-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g24" name="$6_digit-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="number" ag="g23"><nt n="$6_digit-plus" a="p" ag="g24"/><nt n="S" ag="g6"/></r>
 <ag xml:id="g25" name="letter" mark="-"/>
 <r n="letter" ag="g25"><t ag="g4"><cs ag="g5" inclusion="'a'-'z'"/></t></r>
@@ -52,31 +53,31 @@
 <ag xml:id="g26" name="digit" mark="-"/>
 <r n="digit" ag="g26"><t ag="g4"><cs ag="g5" inclusion="'0'-'9'"/></t></r>
 <r n="condition" ag="g13"><nt n="identifier" ag="g18"/></r>
-<ag xml:id="g27" name="$7_L0x20-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g27" name="$7_L0x20-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="S" ag="g6"><nt n="$7_L0x20-star" a="p" ag="g27"/></r>
 <r n="$1_statement-star-sep-option" a="p" ag="g7"></r>
-<ag xml:id="g28" name="$3_statement-plus-sep" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g28" name="$3_statement-plus-sep" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$1_statement-star-sep-option" a="p" ag="g7"><nt n="$3_statement-plus-sep" a="p" ag="g28"/></r>
 <r n="$2_parameter-star-sep-option" a="p" ag="g19"></r>
-<ag xml:id="g29" name="$4_parameter-plus-sep" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g29" name="$4_parameter-plus-sep" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$2_parameter-star-sep-option" a="p" ag="g19"><nt n="$4_parameter-plus-sep" a="p" ag="g29"/></r>
-<ag xml:id="g30" name="$8_L;-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g30" name="$8_L;-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$3_statement-plus-sep" a="p" ag="g28"><nt n="statement" ag="g8"/><nt n="$8_L;-star" a="p" ag="g30"/></r>
-<ag xml:id="g31" name="$9_L,-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g31" name="$9_L,-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$4_parameter-plus-sep" a="p" ag="g29"><nt n="parameter" ag="g20"/><nt n="$9_L,-star" a="p" ag="g31"/></r>
-<ag xml:id="g32" name="$10_letter-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g32" name="$10_letter-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$5_letter-plus" a="p" ag="g22"><nt n="letter" ag="g25"/><nt n="$10_letter-star" a="p" ag="g32"/></r>
-<ag xml:id="g33" name="$11_digit-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g33" name="$11_digit-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$6_digit-plus" a="p" ag="g24"><nt n="digit" ag="g26"/><nt n="$11_digit-star" a="p" ag="g33"/></r>
-<ag xml:id="g34" name="$13_L0x20-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g34" name="$13_L0x20-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$7_L0x20-star" a="p" ag="g27"><nt n="$13_L0x20-option" a="p" ag="g34"/></r>
-<ag xml:id="g35" name="$14_L;-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g35" name="$14_L;-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$8_L;-star" a="p" ag="g30"><nt n="$14_L;-option" a="p" ag="g35"/></r>
-<ag xml:id="g36" name="$15_L,-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g36" name="$15_L,-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$9_L,-star" a="p" ag="g31"><nt n="$15_L,-option" a="p" ag="g36"/></r>
-<ag xml:id="g37" name="$16_letter-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g37" name="$16_letter-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$10_letter-star" a="p" ag="g32"><nt n="$16_letter-option" a="p" ag="g37"/></r>
-<ag xml:id="g38" name="$17_digit-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g38" name="$17_digit-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$11_digit-star" a="p" ag="g33"><nt n="$17_digit-option" a="p" ag="g38"/></r>
 <r n="$12_else-part-option" a="p" ag="g14"></r>
 <r n="$12_else-part-option" a="p" ag="g14"><nt n="else-part" ag="g15"/></r>
@@ -90,6 +91,6 @@
 <r n="$16_letter-option" a="p" ag="g37"><nt n="letter" ag="g25"/><nt n="$10_letter-star" a="p" ag="g32"/></r>
 <r n="$17_digit-option" a="p" ag="g38"></r>
 <r n="$17_digit-option" a="p" ag="g38"><nt n="digit" ag="g26"/><nt n="$11_digit-star" a="p" ag="g33"/></r>
-<check Σ="aadde0e5d3c79254"/>
+<check sum="f44b2b509b396e6c"/>
 </grammar>
 

--- a/src/test/resources/property-file.cxml
+++ b/src/test/resources/property-file.cxml
@@ -1,11 +1,12 @@
-<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="0.9.5">
-<meta name='coffeepot-version' value='1.99.4b'/>
-<meta name='date' value='2022-06-25T08:26:45Z'/>
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="1.99.8">
+<meta name='coffeepot-version' value='1.99.8'/>
+<meta name='date' value='2022-06-30T17:00:27Z'/>
 <meta name='uri' value='file:/Volumes/Projects/nineml/grinder/src/test/resources/property-file.ixml'/>
-<ag xml:id="g1" name="$$" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g1" name="$$" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g2" name="property-file" mark="^"/>
 <r n="$$" a="p" ag="g1"><nt n="property-file" ag="g2"/></r>
-<ag xml:id="g3" name="$2_line-plus" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g3" name="$2_line-plus" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="property-file" ag="g2"><nt n="$2_line-plus" a="p" ag="g3"/></r>
 <ag xml:id="g4" name="line" mark="-"/>
 <ag xml:id="g5" name="blank" mark="^"/>
@@ -21,7 +22,7 @@
 <ag xml:id="g12" name="value" mark="^"/>
 <r n="name-value" ag="g7"><nt n="s" ag="g8"/><nt n="name" ag="g9"/><nt n="s" ag="g8"/><t ag="g10"><cs ag="g11" inclusion="&quot;:=&quot;"/></t><nt n="s" ag="g8"/><nt n="value" ag="g12"/></r>
 <ag xml:id="g13" name="namestart" mark="-"/>
-<ag xml:id="g14" name="$3_namefollower-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g14" name="$3_namefollower-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="name" ag="g9"><nt n="namestart" ag="g13"/><nt n="$3_namefollower-star" a="p" ag="g14"/></r>
 <ag xml:id="g15" name="simple-value" mark="-"/>
 <r n="value" ag="g12"><nt n="simple-value" ag="g15"/></r>
@@ -30,21 +31,21 @@
 <ag xml:id="g17" name="atomic-value" mark="-"/>
 <ag xml:id="g18" name="nl" mark="-"/>
 <r n="simple-value" ag="g15"><nt n="atomic-value" ag="g17"/><nt n="nl" ag="g18"/></r>
-<ag xml:id="g19" name="$4_s-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g19" name="$4_s-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <ag xml:id="g20" name="value" mark="-"/>
 <r n="extended-value" ag="g16"><nt n="atomic-value" ag="g17"/><t ag="g10"><c ag="g11" v="&#x5c;"/></t><nt n="nl" ag="g18"/><nt n="$4_s-star" a="p" ag="g19"/><nt n="value" ag="g20"/></r>
-<ag xml:id="g21" name="$5_s-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
-<ag xml:id="g22" name="$6_any-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g21" name="$5_s-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
+<ag xml:id="g22" name="$6_any-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="atomic-value" ag="g17"><nt n="$5_s-star" a="p" ag="g21"/><nt n="$6_any-star" a="p" ag="g22"/></r>
 <r n="blank" ag="g5"><nt n="s" ag="g8"/><nt n="nl" ag="g18"/></r>
-<ag xml:id="g23" name="$7_star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g23" name="$7_star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="comment" ag="g6"><nt n="s" ag="g8"/><t ag="g10"><cs ag="g11" inclusion="&quot;!#&quot;"/></t><nt n="$7_star" a="p" ag="g23"/><nt n="nl" ag="g18"/></r>
 <ag xml:id="g24" tmark="^"/>
 <r n="namestart" ag="g13"><t ag="g24"><cs ag="g11" inclusion="&quot;_&quot;;L"/></t></r>
 <ag xml:id="g25" name="namefollower" mark="-"/>
 <r n="namefollower" ag="g25"><nt n="namestart" ag="g13"/></r>
 <r n="namefollower" ag="g25"><t ag="g24"><cs ag="g11" inclusion="&quot;⁀·-.‿&quot;;Nd;Mn"/></t></r>
-<ag xml:id="g26" name="$8_$1_alt-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g26" name="$8_$1_alt-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="s" ag="g8"><nt n="$8_$1_alt-star" a="p" ag="g26"/></r>
 <ag xml:id="g27" name="any" mark="-"/>
 <r n="any" ag="g27"><t ag="g24"><cs ag="g11" exclusion="&quot;&#x5c;&quot;;'&#xa;'"/></t></r>
@@ -59,25 +60,25 @@
 <r n="digit" ag="g29"><t ag="g24"><cs ag="g11" inclusion="'0'-'9';'a'-'f';'A'-'F'"/></t></r>
 <r n="nl" ag="g18"><t ag="g10"><c ag="g11" v="&#xa;"/></t></r>
 <r n="nl" ag="g18"><t ag="g10"><c ag="g11" v="&#xd;"/></t><t ag="g10"><c ag="g11" v="&#xa;"/></t></r>
-<ag xml:id="g30" name="$1_alt" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g30" name="$1_alt" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$1_alt" a="p" ag="g30"><t ag="g10"><cs ag="g11" inclusion="Zs"/></t></r>
 <r n="$1_alt" a="p" ag="g30"><t ag="g10"><c ag="g11" v="&#x9;"/></t></r>
 <r n="$1_alt" a="p" ag="g30"><t ag="g10"><c ag="g11" v="&#xd;"/></t></r>
-<ag xml:id="g31" name="$9_line-star" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g31" name="$9_line-star" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$2_line-plus" a="p" ag="g3"><nt n="line" ag="g4"/><nt n="$9_line-star" a="p" ag="g31"/></r>
-<ag xml:id="g32" name="$10_namefollower-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g32" name="$10_namefollower-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$3_namefollower-star" a="p" ag="g14"><nt n="$10_namefollower-option" a="p" ag="g32"/></r>
-<ag xml:id="g33" name="$11_s-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g33" name="$11_s-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$4_s-star" a="p" ag="g19"><nt n="$11_s-option" a="p" ag="g33"/></r>
-<ag xml:id="g34" name="$12_s-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g34" name="$12_s-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$5_s-star" a="p" ag="g21"><nt n="$12_s-option" a="p" ag="g34"/></r>
-<ag xml:id="g35" name="$13_any-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g35" name="$13_any-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$6_any-star" a="p" ag="g22"><nt n="$13_any-option" a="p" ag="g35"/></r>
-<ag xml:id="g36" name="$14_option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g36" name="$14_option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$7_star" a="p" ag="g23"><nt n="$14_option" a="p" ag="g36"/></r>
-<ag xml:id="g37" name="$15_$1_alt-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g37" name="$15_$1_alt-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$8_$1_alt-star" a="p" ag="g26"><nt n="$15_$1_alt-option" a="p" ag="g37"/></r>
-<ag xml:id="g38" name="$16_line-option" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.attrǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g38" name="$16_line-option" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
 <r n="$9_line-star" a="p" ag="g31"><nt n="$16_line-option" a="p" ag="g38"/></r>
 <r n="$10_namefollower-option" a="p" ag="g32"></r>
 <r n="$10_namefollower-option" a="p" ag="g32"><nt n="namefollower" ag="g25"/><nt n="$3_namefollower-star" a="p" ag="g14"/></r>
@@ -93,6 +94,6 @@
 <r n="$15_$1_alt-option" a="p" ag="g37"><nt n="$1_alt" a="p" ag="g30"/><nt n="$8_$1_alt-star" a="p" ag="g26"/></r>
 <r n="$16_line-option" a="p" ag="g38"></r>
 <r n="$16_line-option" a="p" ag="g38"><nt n="line" ag="g4"/><nt n="$9_line-star" a="p" ag="g31"/></r>
-<check Σ="10a9854192f8211d"/>
+<check sum="a9604342b6cfff52"/>
 </grammar>
 


### PR DESCRIPTION
On Windows, the compiled grammar's use of non-ASCII characters caused problems. See #72 

I also noticed that I'd introduced a `CompiledGrammar` class that had nothing to do with the `GrammarCompiler` in utils. That seemd like it was going to be confusing, so the `CompiledGrammar` object is now called `ParserGrammar`.