### PR TITLE
Improve what's exposed in RuleChoices

### DIFF
--- a/src/main/java/org/nineml/coffeegrinder/parser/Family.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/Family.java
@@ -96,23 +96,13 @@ public class Family implements RuleChoice {
     }
 
     @Override
-    public int getLeftExtent() {
-        if (v == null) {
-            // How *is* the left extent of an epsilon represented?
-            return -1;
-        }
-        if (w == null) {
-            return v.leftExtent;
-        }
-        return w.leftExtent;
+    public ForestNode getLeftNode() {
+        return w;
     }
 
     @Override
-    public int getRightExtent() {
-        if (v == null) {
-            return -1;
-        }
-        return v.rightExtent;
+    public ForestNode getRightNode() {
+        return v;
     }
 
     @Override

--- a/src/main/java/org/nineml/coffeegrinder/parser/ForestNode.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/ForestNode.java
@@ -264,13 +264,13 @@ public class ForestNode implements RuleChoice {
     }
 
     @Override
-    public int getLeftExtent() {
-        return leftExtent;
+    public ForestNode getLeftNode() {
+        return null;
     }
 
     @Override
-    public int getRightExtent() {
-        return rightExtent;
+    public ForestNode getRightNode() {
+        return this;
     }
 
     public Symbol[] getRightHandSide() {

--- a/src/main/java/org/nineml/coffeegrinder/parser/RuleChoice.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/RuleChoice.java
@@ -3,6 +3,6 @@ package org.nineml.coffeegrinder.parser;
 public interface RuleChoice {
     Symbol getSymbol();
     Symbol[] getRightHandSide();
-    int getLeftExtent();
-    int getRightExtent();
+    ForestNode getLeftNode();
+    ForestNode getRightNode();
 }


### PR DESCRIPTION
Rather than attempting to paper over the choice of ForestNodes, expose them. This makes it possible to provide better descriptions of the ambiguity. (In particular, sometimes the different ranges in the left- and right-hand sides matter)