### PR TITLE
Attempt to resolve the bug where the GLL parser gets marks wrong

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 cgName=coffeegrinder
 cgTitle=CoffeeGrinder
-cgVersion=1.99.11
+cgVersion=1.99.12
 
 xmlresolverVersion=4.5.1
 docbookVersion=5.2CR2

--- a/src/main/java/org/nineml/coffeegrinder/gll/BinarySubtree.java
+++ b/src/main/java/org/nineml/coffeegrinder/gll/BinarySubtree.java
@@ -107,7 +107,7 @@ public class BinarySubtree {
     }
 
     protected ParseForest extractSPPF(ParserGrammar grammar, Token[] inputTokens) {
-        ParseForestGLL G = new ParseForestGLL(grammar.getParserOptions(), grammar, rightExtent, inputTokens, regexMatches);
+        ParseForestGLL G = new ParseForestGLL(options, grammar, rightExtent, inputTokens, regexMatches);
         int n = rightExtent;
 
         if (getRoots().isEmpty()) {

--- a/src/main/java/org/nineml/coffeegrinder/parser/ParseForest.java
+++ b/src/main/java/org/nineml/coffeegrinder/parser/ParseForest.java
@@ -227,7 +227,6 @@ public class ParseForest {
                 }
         }
 
-        int choiceCount = families.size();
         if (!families.isEmpty()) {
             Family family = families.get(index);
             // Don't advance an epsilon edge, leave it as an escape hatch.
@@ -243,23 +242,29 @@ public class ParseForest {
             }
         }
 
-        if (child1 != null) {
-            int pos = getSymbol(child1.getSymbol(), state, state.getPosition());
-            if (pos >= 0) {
-                child1Symbol = state.getRhs().get(pos);
-            } else {
-                pos = state.getPosition();
-            }
+        // When the GLL parser builds the forest, the states associated with nodes in the tree
+        // are sometimes associated with the node's parent symbol. I dunno why. But if the
+        // state symbol isn't the same as the tree symbol, don't go looking at its RHS.
+        if ("Earley".equals(options.getParserType())
+                || tree.getSymbol() == null || tree.getSymbol().equals(state.getSymbol())) {
+            if (child1 != null) {
+                int pos = getSymbol(child1.getSymbol(), state, state.getPosition());
+                if (pos >= 0) {
+                    child1Symbol = state.getRhs().get(pos);
+                } else {
+                    pos = state.getPosition();
+                }
 
-            pos = getSymbol(child0.getSymbol(), state, pos); // don't "pass" the second symbol
-            if (pos >= 0) {
-                child0Symbol = state.getRhs().get(pos);
-            }
-        } else {
-            if (child0 != null) {
-                int pos = getSymbol(child0.getSymbol(), state, state.getPosition());
+                pos = getSymbol(child0.getSymbol(), state, pos); // don't "pass" the second symbol
                 if (pos >= 0) {
                     child0Symbol = state.getRhs().get(pos);
+                }
+            } else {
+                if (child0 != null) {
+                    int pos = getSymbol(child0.getSymbol(), state, state.getPosition());
+                    if (pos >= 0) {
+                        child0Symbol = state.getRhs().get(pos);
+                    }
                 }
             }
         }

--- a/src/main/java/org/nineml/coffeegrinder/util/PrintStreamTreeBuilder.java
+++ b/src/main/java/org/nineml/coffeegrinder/util/PrintStreamTreeBuilder.java
@@ -1,0 +1,80 @@
+package org.nineml.coffeegrinder.util;
+
+import org.nineml.coffeegrinder.parser.NonterminalSymbol;
+import org.nineml.coffeegrinder.tokens.Token;
+import org.nineml.coffeegrinder.tokens.TokenCharacter;
+import org.nineml.coffeegrinder.tokens.TokenString;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+
+public class PrintStreamTreeBuilder extends PriorityTreeBuilder {
+    protected String tab = "  ";
+    protected String nl = "\n";
+    private String indent = "";
+    private StringBuilder sb = null;
+    private PrintStream stream;
+
+    public PrintStreamTreeBuilder() {
+        stream = null;
+    }
+
+    public PrintStreamTreeBuilder(PrintStream stream) {
+        this.stream = stream;
+    }
+
+    public void setStream(PrintStream stream) {
+        if (this.stream != null) {
+            throw new RuntimeException("Stream cannot be changed");
+        }
+        this.stream = stream;
+    }
+
+    @Override
+    public void startNonterminal(NonterminalSymbol symbol, Map<String,String> attributes, int leftExtent, int rightExtent) {
+        if (sb != null) {
+            stream.printf("%s%s%s", indent, sb, nl);
+            sb = null;
+        }
+        stream.printf("%s<%s", indent, symbol);
+        for (String name : attributes.keySet()) {
+            if (!"name".equals(name)) {
+                stream.printf(" %s=\"%s\"", name, attributes.get(name));
+            }
+        }
+
+        stream.printf(">%s", nl);
+        indent = indent + tab;
+    }
+
+    @Override
+    public void endNonterminal(NonterminalSymbol symbol, Map<String,String> attributes, int leftExtent, int rightExtent) {
+        if (sb != null) {
+            stream.printf("%s%s%s", indent, sb, nl);
+            sb = null;
+        }
+        indent = indent.substring(tab.length());
+        stream.printf("%s</%s>%s", indent, symbol, nl);
+    }
+
+    @Override
+    public void token(Token token, Map<String,String> attributes) {
+        if (sb == null) {
+            sb = new StringBuilder();
+        }
+        if (token instanceof TokenCharacter) {
+            int cp = ((TokenCharacter) token).getCodepoint();
+            if (cp == '<' || cp == '>' || cp == '&' || cp <= ' ') {
+                sb.append(String.format("&#x%x;", cp));
+            } else {
+                sb.appendCodePoint(cp);
+            }
+        } else if (token instanceof TokenString) {
+            sb.append(token.getValue());
+        } else {
+            sb.append(token.toString());
+        }
+    }
+}

--- a/src/main/java/org/nineml/coffeegrinder/util/StdoutTreeBuilder.java
+++ b/src/main/java/org/nineml/coffeegrinder/util/StdoutTreeBuilder.java
@@ -11,47 +11,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-public class StdoutTreeBuilder extends PriorityTreeBuilder {
-    private static final String tab = "  ";
-    private String indent = "";
-    private StringBuilder sb = null;
-
-    @Override
-    public void startNonterminal(NonterminalSymbol symbol, Map<String,String> attributes, int leftExtent, int rightExtent) {
-        if (sb != null) {
-            System.out.printf("%s%s%n", indent, sb);
-            sb = null;
-        }
-        System.out.printf("%s<%s>%n", indent, symbol);
-        indent = indent + tab;
-    }
-
-    @Override
-    public void endNonterminal(NonterminalSymbol symbol, Map<String,String> attributes, int leftExtent, int rightExtent) {
-        if (sb != null) {
-            System.out.printf("%s%s%n", indent, sb);
-            sb = null;
-        }
-        indent = indent.substring(tab.length());
-        System.out.printf("%s</%s>%n", indent, symbol);
-    }
-
-    @Override
-    public void token(Token token, Map<String,String> attributes) {
-        if (sb == null) {
-            sb = new StringBuilder();
-        }
-        if (token instanceof TokenCharacter) {
-            int cp = ((TokenCharacter) token).getCodepoint();
-            if (cp == '<' || cp == '>' || cp == '&' || cp <= ' ') {
-                sb.append(String.format("&#x%x;", cp));
-            } else {
-                sb.appendCodePoint(cp);
-            }
-        } else if (token instanceof TokenString) {
-            sb.append(token.getValue());
-        } else {
-            sb.append(token.toString());
-        }
+public class StdoutTreeBuilder extends PrintStreamTreeBuilder {
+    public StdoutTreeBuilder() {
+        super(System.out);
     }
 }

--- a/src/main/java/org/nineml/coffeegrinder/util/StringTreeBuilder.java
+++ b/src/main/java/org/nineml/coffeegrinder/util/StringTreeBuilder.java
@@ -1,0 +1,30 @@
+package org.nineml.coffeegrinder.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+
+public class StringTreeBuilder extends PrintStreamTreeBuilder {
+    private ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    public StringTreeBuilder() {
+        tab = "";
+        nl = "";
+        try {
+            PrintStream stream = new PrintStream(baos, true, "UTF-8");
+            setStream(stream);
+        } catch (UnsupportedEncodingException ex) {
+            // this can't happen...
+            throw new RuntimeException(ex.getMessage());
+        }
+    }
+
+    public String getTree() {
+        try {
+            return baos.toString("UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            // this can't happen...
+            throw new RuntimeException(ex.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/nineml/coffeegrinder/MarkTest.java
+++ b/src/test/java/org/nineml/coffeegrinder/MarkTest.java
@@ -1,0 +1,114 @@
+package org.nineml.coffeegrinder;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.nineml.coffeegrinder.parser.*;
+import org.nineml.coffeegrinder.util.GrammarCompiler;
+import org.nineml.coffeegrinder.util.StdoutTreeBuilder;
+import org.nineml.coffeegrinder.util.StringTreeBuilder;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static junit.framework.TestCase.fail;
+
+public class MarkTest {
+    private String loadCxml(String filename) {
+        String cxml = null;
+        try {
+            InputStreamReader reader = new InputStreamReader(Files.newInputStream(Paths.get(filename)), StandardCharsets.UTF_8);
+            StringBuilder sb = new StringBuilder();
+            char[] buffer = new char[4096];
+            int len = reader.read(buffer);
+            while (len >= 0) {
+                sb.append(buffer, 0, len);
+                len = reader.read(buffer);
+            }
+            cxml = sb.toString();
+        } catch (IOException ex) {
+            fail();
+        }
+        return cxml;
+    }
+
+    @Test
+    public void parseEarley() {
+        String cxml = loadCxml("src/test/resources/sg54bis.cxml");
+        GrammarCompiler compiler = new GrammarCompiler();
+        SourceGrammar grammar = compiler.parse(cxml);
+
+        NonterminalSymbol S = grammar.getNonterminal("Number");
+
+        ParserOptions options = new ParserOptions();
+        options.setParserType("Earley");
+
+        GearleyParser parser = grammar.getParser(options, S);
+        GearleyResult result = parser.parse("32.5e+1");
+        Assertions.assertTrue(result.succeeded());
+
+        StringTreeBuilder builder = new StringTreeBuilder();
+        result.getTree(builder);
+
+        String tree = builder.getTree();
+        int pos = tree.indexOf("<Integer");
+        tree = tree.substring(pos);
+        pos = tree.indexOf("<Fraction");
+        tree = tree.substring(0, pos);
+
+        Assertions.assertEquals("<Integer mark=\"^\"><Integer mark=\"-\">3</Integer><Digit mark=\"-\">2</Digit></Integer>", tree);
+    }
+
+    @Test
+    public void parseSg54bisGLL() {
+        String cxml = loadCxml("src/test/resources/sg54bis.cxml");
+        GrammarCompiler compiler = new GrammarCompiler();
+        SourceGrammar grammar = compiler.parse(cxml);
+
+        NonterminalSymbol S = grammar.getNonterminal("Number");
+
+        ParserOptions options = new ParserOptions();
+        options.setParserType("GLL");
+
+        GearleyParser parser = grammar.getParser(options, S);
+        GearleyResult result = parser.parse("32.5e+1");
+        Assertions.assertTrue(result.succeeded());
+
+        StringTreeBuilder builder = new StringTreeBuilder();
+        result.getTree(builder);
+
+        String tree = builder.getTree();
+
+        int pos = tree.indexOf("<Integer");
+        tree = tree.substring(pos);
+        pos = tree.indexOf("<Fraction");
+        tree = tree.substring(0, pos);
+
+        Assertions.assertEquals("<Integer mark=\"^\"><Integer mark=\"-\">3</Integer><Digit mark=\"-\">2</Digit></Integer>", tree);
+    }
+
+    @Test
+    public void parseInsMultAttGLL() {
+        String cxml = loadCxml("src/test/resources/insmultatt.cxml");
+        GrammarCompiler compiler = new GrammarCompiler();
+        SourceGrammar grammar = compiler.parse(cxml);
+
+        NonterminalSymbol S = grammar.getNonterminal("S");
+
+        ParserOptions options = new ParserOptions();
+        options.setParserType("GLL");
+
+        GearleyParser parser = grammar.getParser(options, S);
+        GearleyResult result = parser.parse("a");
+        Assertions.assertTrue(result.succeeded());
+
+        StringTreeBuilder builder = new StringTreeBuilder();
+        result.getTree(builder);
+        String tree = builder.getTree();
+
+        Assertions.assertTrue(tree.contains("<b mark=\"@\">"));
+    }
+
+}

--- a/src/test/resources/insmultatt.cxml
+++ b/src/test/resources/insmultatt.cxml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="1.99.8">
+<ag xml:id="g1" name="$$" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
+<ag xml:id="g2" name="S" mark="^"/>
+<r n="$$" a="p" ag="g1"><nt n="S" ag="g2"/></r>
+<ag xml:id="g3" tmark="^"/>
+<ag xml:id="g4"/>
+<ag xml:id="g5" name="b" mark="^"/>
+<ag xml:id="g6" name="b" mark="@"/>
+<r n="S" ag="g2"><t ag="g3"><c ag="g4" v="a"/></t><nt n="b" ag="g5"/><nt n="b" ag="g6"/><nt n="b" ag="g5"/></r>
+<ag xml:id="g7" insertion="xml" mark="+"/>
+<r n="$1_+xml" ag="g7"></r>
+<r n="b" ag="g5"><nt n="$1_+xml" ag="g7"/></r>
+<check sum="40066b3aad410c86"/>
+</grammar>

--- a/src/test/resources/sg54bis.cxml
+++ b/src/test/resources/sg54bis.cxml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="1.99.8">
+<ag xml:id="g1" name="$$" httpsE3a.E2f.E2f.ninemlE2e.orgE2f.attrE2f.prune="allowed" mark="-"/>
+<ag xml:id="g2" name="Number" mark="^"/>
+<r n="$$" a="p" ag="g1"><nt n="Number" ag="g2"/></r>
+<ag xml:id="g3" tmark="^"/>
+<ag xml:id="g4"/>
+<r n="Number" ag="g2"><t ag="g3"><cs ag="g4" inclusion="'0'-'9'"/></t></r>
+<ag xml:id="g5" name="Integer" mark="-"/>
+<ag xml:id="g6" name="Digit" mark="-"/>
+<r n="Number" ag="g2"><nt n="Integer" ag="g5"/><nt n="Digit" ag="g6"/></r>
+<ag xml:id="g7" name="N1" mark="-"/>
+<ag xml:id="g8" name="Scale1" mark="^"/>
+<r n="Number" ag="g2"><nt n="N1" ag="g7"/><nt n="Scale1" ag="g8"/></r>
+<ag xml:id="g9" name="Integer" mark="^"/>
+<ag xml:id="g10" name="Fraction" mark="^"/>
+<r n="Number" ag="g2"><nt n="Integer" ag="g9"/><nt n="Fraction" ag="g10"/></r>
+<r n="N1" ag="g7"><nt n="Integer" ag="g9"/><nt n="Fraction" ag="g10"/></r>
+<r n="Integer" ag="g9"><t ag="g3"><cs ag="g4" inclusion="'0'-'9'"/></t></r>
+<r n="Integer" ag="g9"><nt n="Integer" ag="g5"/><nt n="Digit" ag="g6"/></r>
+<ag xml:id="g11" name="T1" mark="-"/>
+<r n="Fraction" ag="g10"><nt n="T1" ag="g11"/><nt n="Integer" ag="g5"/></r>
+<r n="T1" ag="g11"><t ag="g3"><c ag="g4" v="."/></t></r>
+<ag xml:id="g12" name="N2" mark="-"/>
+<r n="Scale1" ag="g8"><nt n="N2" ag="g12"/><nt n="Integer" ag="g9"/></r>
+<ag xml:id="g13" name="T2" mark="-"/>
+<ag xml:id="g14" name="Sign" mark="^"/>
+<r n="N2" ag="g12"><nt n="T2" ag="g13"/><nt n="Sign" ag="g14"/></r>
+<r n="T2" ag="g13"><t ag="g3"><c ag="g4" v="e"/></t></r>
+<r n="Digit" ag="g6"><t ag="g3"><cs ag="g4" inclusion="'0'-'9'"/></t></r>
+<r n="Sign" ag="g14"><t ag="g3"><cs ag="g4" inclusion="&quot;+&quot;;&quot;-&quot;"/></t></r>
+<check sum="eb3472f4c95f1599"/>
+</grammar>


### PR DESCRIPTION
This one is ugly. The way the parse forest is construced by the GLL parser sometimes leaves the "states" unchanged from the parent nodes in the forest. So we try to ignore that case. But I'd be a lot happier if I understood exactly why.